### PR TITLE
Cursor API for Sequential Storage

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -159,6 +159,11 @@ Right click project, Click "Open Configuration", Click "Make" icon, "Number of s
 
 Running Tests (For FOEDUS Developers)
 --------
+**First**, make sure you have set up the environment, especially hugepages/shared memory.
+See the *Environment Setup* section in [foedus-core](foedus-core).
+If a large number of tests fail, it's most likely cauesed by memory/permission issues.
+
+
 Go to build folder, and:
 
     ctest

--- a/experiments-core/src/foedus/tpcc/README.markdown
+++ b/experiments-core/src/foedus/tpcc/README.markdown
@@ -24,7 +24,7 @@ with detailed steps to reproduce them. Unless individually noted,
 
 Target Systems
 -----------------
-Under this folder, we have experiments to test three sets of systems.
+Under this folder, we have experiments to run three systems.
 
 * FOEDUS. Scripts/programs in this folder.
 * H-Store. Files under [hstore_related](hstore_related).
@@ -33,7 +33,7 @@ Under this folder, we have experiments to test three sets of systems.
 This document focuses on FOEDUS experiments. Go to sub folders for H-Store/SILO experiments.
 
 Actually, we have fourth system in the paper, Shore-MT.
-What we used was HP's intenval version with Foster B-tree and a few other improvements.
+What we used was HP's internal version with Foster B-tree and a few other improvements.
 It is not OSS-ed. Most likely the EPFL's version of Shore-MT has a similar performance, though.
 
 Machine Sizing and Scripts

--- a/foedus-core/include/foedus/memory/engine_memory.hpp
+++ b/foedus-core/include/foedus/memory/engine_memory.hpp
@@ -56,6 +56,19 @@ class EngineMemory CXX11_FINAL : public DefaultInitializable {
   ErrorStack  initialize_once() CXX11_OVERRIDE;
   ErrorStack  uninitialize_once() CXX11_OVERRIDE;
 
+  /**
+   * As part of the global shared memory, we reserve this size of 'user memory' that can be
+   * used for arbitrary purporses by the user to communicate between SOCs.
+   * @see get_shared_user_memory_size()
+   */
+  void*     get_shared_user_memory() const;
+  /**
+   * @returns the byte size of shared user-controlled memory.
+   * Equivalent to SocOptions.shared_user_memory_size_kb_ << 10.
+   * @see get_shared_user_memory()
+   */
+  uint64_t  get_shared_user_memory_size() const;
+
   // accessors for child memories
   NumaNodeMemory* get_local_memory() const {
     return local_memory_;

--- a/foedus-core/include/foedus/memory/page_pool.hpp
+++ b/foedus-core/include/foedus/memory/page_pool.hpp
@@ -187,6 +187,18 @@ class PagePool CXX11_FINAL : public virtual Initializable {
 
   storage::Page*        get_base() const;
   uint64_t              get_memory_size() const;
+  /**
+   * @returns recommended number of pages to grab at once.
+   * @details
+   * Especially in testcases, grabbing chunk-full of pages (4k pages) at a time
+   * immediately runs out of free pages
+   * unless we allocate huge pools for each run, which would make test-time significantly longer.
+   * For example, if the pool has only 1024 pages, it doesn't make sense to
+   * grab 2000 pages at a time! As soon as one thread does it, all other threads
+   * will get out-of-memory error although the culprit probably needs only a few pages.
+   * To avoid that, we respect this value in most places.
+   */
+  uint32_t              get_recommended_pages_per_grab() const;
   Stat                  get_stat() const;
   std::string           get_debug_pool_name() const;
   /** Call this anytime after attach() */

--- a/foedus-core/include/foedus/savepoint/savepoint.hpp
+++ b/foedus-core/include/foedus/savepoint/savepoint.hpp
@@ -65,6 +65,13 @@ struct Savepoint CXX11_FINAL : public virtual externalize::Externalizable {
   Epoch::EpochInteger             durable_epoch_;
 
   /**
+   * The earliest epoch that can exist in this system. it advances only after we
+   * do a system-wide compaction. Otherwise, it's kEpochInitialDurable, which is indeed
+   * the earliest until the epoch wraps around.
+   */
+  Epoch::EpochInteger             earliest_epoch_;
+
+  /**
    * The most recent complete snapshot.
    * kNullSnapshotId if no snapshot has been taken yet.
    */

--- a/foedus-core/include/foedus/savepoint/savepoint_manager.hpp
+++ b/foedus-core/include/foedus/savepoint/savepoint_manager.hpp
@@ -57,6 +57,7 @@ class SavepointManager CXX11_FINAL : public virtual Initializable {
 
   Epoch get_initial_current_epoch() const;
   Epoch get_initial_durable_epoch() const;
+  Epoch get_earliest_epoch() const;
   Epoch get_saved_durable_epoch() const;
   snapshot::SnapshotId get_latest_snapshot_id() const;
   Epoch get_latest_snapshot_epoch() const;

--- a/foedus-core/include/foedus/savepoint/savepoint_manager_pimpl.hpp
+++ b/foedus-core/include/foedus/savepoint/savepoint_manager_pimpl.hpp
@@ -54,6 +54,7 @@ struct SavepointManagerControlBlock {
   std::atomic<bool>   master_initialized_;
   Epoch::EpochInteger initial_current_epoch_;
   Epoch::EpochInteger initial_durable_epoch_;
+  Epoch::EpochInteger earliest_epoch_;
 
   /**
    * savepoint thread sleeps on this condition variable.
@@ -115,6 +116,7 @@ class SavepointManagerPimpl final : public DefaultInitializable {
 
   Epoch get_initial_current_epoch() const { return Epoch(control_block_->initial_current_epoch_); }
   Epoch get_initial_durable_epoch() const { return Epoch(control_block_->initial_durable_epoch_); }
+  Epoch get_earliest_epoch() const { return Epoch(control_block_->earliest_epoch_); }
   Epoch get_saved_durable_epoch() const { return Epoch(control_block_->saved_durable_epoch_); }
   snapshot::SnapshotId get_latest_snapshot_id() const {
     return control_block_->savepoint_.latest_snapshot_id_;

--- a/foedus-core/include/foedus/snapshot/snapshot_manager.hpp
+++ b/foedus-core/include/foedus/snapshot/snapshot_manager.hpp
@@ -64,11 +64,16 @@ class SnapshotManager CXX11_FINAL : public virtual Initializable {
   /**
    * @brief Immediately take a snapshot
    * @param[in] wait_completion whether to block until the completion of entire snapshotting
+   * @param[in] suggested_snapshot_epoch the epoch up to which we will snapshot.
+   * Must be a durable epoch that is after the previous snapshot epoch.
+   * If not specified, the latest durable epoch is used, which is in most cases what you want.
    * @details
    * This method is used to immediately take snapshot for either recovery or memory-saving
    * purpose.
    */
-  void    trigger_snapshot_immediate(bool wait_completion);
+  void    trigger_snapshot_immediate(
+    bool wait_completion,
+    Epoch suggested_snapshot_epoch = INVALID_EPOCH);
 
   /** Do not use this unless you know what you are doing. */
   SnapshotManagerPimpl* get_pimpl() { return pimpl_; }

--- a/foedus-core/include/foedus/snapshot/snapshot_manager_pimpl.hpp
+++ b/foedus-core/include/foedus/snapshot/snapshot_manager_pimpl.hpp
@@ -222,7 +222,9 @@ class SnapshotManagerPimpl final : public DefaultInitializable {
 
   ErrorStack read_snapshot_metadata(SnapshotId snapshot_id, SnapshotMetadata* out);
 
-  void    trigger_snapshot_immediate(bool wait_completion);
+  void    trigger_snapshot_immediate(
+    bool wait_completion,
+    Epoch suggested_snapshot_epoch);
   /**
    * This is a hidden API called at the beginning of engine shutdown (namely restart manager).
    * Snapshot Manager initializes before Storage because it must \e read previous snapshot,

--- a/foedus-core/include/foedus/soc/soc_manager.hpp
+++ b/foedus-core/include/foedus/soc/soc_manager.hpp
@@ -76,6 +76,14 @@ class SocManager CXX11_FINAL : public virtual Initializable {
   /** Returns the shared memories maintained across SOCs */
   SharedMemoryRepo* get_shared_memory_repo();
 
+  /** Shortcut for get_shared_memory_repo()->get_global_user_memory() */
+  void*     get_shared_user_memory() const;
+  /**
+   * @returns the byte size of shared user-controlled memory.
+   * Equivalent to SocOptions.shared_user_memory_size_kb_ << 10.
+   */
+  uint64_t  get_shared_user_memory_size() const;
+
   /**
    * @brief Wait for master engine to finish init/uninit the module.
    */

--- a/foedus-core/include/foedus/storage/sequential/fwd.hpp
+++ b/foedus-core/include/foedus/storage/sequential/fwd.hpp
@@ -32,6 +32,8 @@ struct  SequentialMetadata;
 class   SequentialPage;
 class   SequentialPartitioner;
 class   SequentialRootPage;
+struct  SequentialRecordBatch;
+class   SequentialRecordIterator;
 class   SequentialStorage;
 struct  SequentialStorageControlBlock;
 class   SequentialStorageFactory;

--- a/foedus-core/include/foedus/storage/sequential/sequential_cursor.hpp
+++ b/foedus-core/include/foedus/storage/sequential/sequential_cursor.hpp
@@ -20,24 +20,59 @@
 
 #include <stdint.h>
 
+#include <algorithm>
+#include <cstring>
+#include <iosfwd>
+#include <vector>
+
+#include "foedus/assert_nd.hpp"
+#include "foedus/cxx11.hpp"
 #include "foedus/epoch.hpp"
+#include "foedus/storage/page.hpp"
 #include "foedus/storage/storage_id.hpp"
 #include "foedus/storage/sequential/fwd.hpp"
 #include "foedus/storage/sequential/sequential_id.hpp"
 #include "foedus/storage/sequential/sequential_storage.hpp"
 #include "foedus/thread/fwd.hpp"
+#include "foedus/xct/fwd.hpp"
+#include "foedus/xct/xct_id.hpp"
 
 namespace foedus {
 namespace storage {
 namespace sequential {
-
 /**
  * @brief A cursor interface to read tuples from a sequential storage.
  * @ingroup SEQUENTIAL
  * @details
  * Unlike other storages, the only read-access to sequential storages is,
  * as the name implies, a full sequential scan. This cursor interface is
- * thus optimized for cases where we return millions of tuples.
+ * thus optimized for cases where we scan millions of records.
+ * This implies that, unlike masstree's cursor, we don't have to worry about
+ * infrequent overheads, such as new/delete in initialization.
+ *
+ * @par Example first
+ * Use it as follows.
+ * @code{.cpp}
+ * memory::AlignedMemory buffer(1 << 16, 1 << 12, kNumaAllocOnnode, 0);
+ * SequentialCursor cursor(context, storage, buffer.get_block(), 1 << 16);
+ * SequentialRecordIterator it;
+ * while (cursor.is_valid()) {
+ *   CHECK_ERROR(cursor.next_batch(&it));
+ *   while (it.is_valid()) {
+ *     std::cout << std::string(it.get_cur_record_raw(), it.get_cur_record_length());
+ *     ...
+ *     it.next();
+ *   }
+ * }
+ * @endcode
+ *
+ * @par Safe Epoch and Unsafe Epoch
+ * Safe epochs are epochs before the current global epoch.
+ * There will be no more transactions in such epochs. Thus, thanks to the append-only
+ * nature of sequential storage, reading records in safe epochs does not need
+ * any concurrency control. Unsafe epochs, OTOH, are the currrent global epoch or
+ * future epochs. This cursor might do expensive synchronization if the user
+ * requests to read records from unsafe epochs.
  */
 class SequentialCursor {
  public:
@@ -50,18 +85,11 @@ class SequentialCursor {
      */
     kNodeFirstMode,
     /**
-     * Returns the earlise epoch's records, then next epoch, ...
+     * Returns records \b loosely ordered by epochs.
+     * We don't guarantee true ordering even in this case, which is too expensive.
      * TASK(Hideaki) \b Not \b implemented \b yet.
      */
-    kEpochFirstMode,
-  };
-
-  /**
-   * @brief Represents the progress of this cursor on each SOC node.
-   * @details
-   * For each next_batch() call, we resume reading based on these information.
-   */
-  struct NodeState {
+    kLooseEpochSortMode,
   };
 
   /**
@@ -69,22 +97,19 @@ class SequentialCursor {
    * @param[in] context Thread context of the transaction
    * @param[in] storage The sequential storage to read from
    * @param[in,out] buffer The buffer to read a number of tuples in a batch.
+   * This buffer \b must \b be \b aligned for direct-IO.
    * @param[in] buffer_size Byte size of buffer. Must be at least 4kb.
    * @param[in] order_mode The order this cursor returns tuples
    * @param[in] from_epoch Inclusive beginning of epochs to read.
-   * @param[in] to_epoch Exclusive end of epochs to read.
-   */
-  SequentialCursor(
-    thread::Thread* context,
-    const sequential::SequentialStorage& storage,
-    void* buffer,
-    uint64_t buffer_size,
-    OrderMode order_mode,
-    Epoch from_epoch,
-    Epoch to_epoch);
-
-  /**
-   * This overload uses the system-initial epoch for from_epoch and system-current epoch -1
+   * If not specified, all epochs.
+   * @param[in] to_epoch Exclusive end of epochs to read. To read records in unsafe epochs,
+   * specify a _future_ epoch, larger than the current global epoch (remember, it's exclusive end).
+   * If not specified, all \e safe epochs (fast, but does not return records being added).
+   * @param[in] node_filter If specified, returns records only in the given node. negative
+   * for reading from all nodes. This is especially useful for parallelizing a scan on
+   * a large sequential storage.
+   * @details
+   * Default parameter: the system-initial epoch for from_epoch and current-global epoch
    * for to_epoch (thus safe_epoch_only_). Assuming this storage is used for log/archive data,
    * this should be a quite common usecase. order_mode is defaulted to kNodeFirstMode.
    */
@@ -92,7 +117,11 @@ class SequentialCursor {
     thread::Thread* context,
     const sequential::SequentialStorage& storage,
     void* buffer,
-    uint64_t buffer_size);
+    uint64_t buffer_size,
+    OrderMode order_mode = kNodeFirstMode,
+    Epoch from_epoch = INVALID_EPOCH,
+    Epoch to_epoch = INVALID_EPOCH,
+    int32_t node_filter = -1);
 
   ~SequentialCursor();
 
@@ -103,25 +132,69 @@ class SequentialCursor {
   Epoch     get_from_epoch() const { return from_epoch_; }
   /** @return Exclusive end of epochs to read. */
   Epoch     get_to_epoch() const { return to_epoch_; }
-  /** @returns Number of tuples read so far. Just a statistics. */
-  uint64_t  get_tuples_so_far() const { return tuples_so_far_; }
+
+  /**
+   * @brief Returns a batch of records as an iterator.
+   * @param[out] out an iterator over returned records.
+   * @details
+   * It \e might return an empty batch even when this cursor has more records to return.
+   * Invoke is_valid() to check it. This method does nothing if is_valid() is already false.
+   * Each batch is guaranteed to be from one node, and actually from one page.
+   */
+  ErrorCode next_batch(SequentialRecordIterator* out);
+
+  bool      is_valid() const {
+    return !(finished_snapshots_ && finished_safe_volatiles_ && finished_unsafe_volatiles_);
+  }
+
+  friend std::ostream& operator<<(std::ostream& o, const SequentialCursor& v);
 
  private:
+  /**
+   * @brief Represents the progress of this cursor on each SOC node.
+   * @details
+   * For each next_batch() call, we resume reading based on these information.
+   */
+  struct NodeState {
+    explicit NodeState(uint16_t node_id);
+    ~NodeState();
+    const uint16_t                node_id_;
+    uint32_t                      snapshot_cur_head_;
+    uint64_t                      snapshot_cur_head_read_pages_;
+    std::vector<HeadPagePointer>  snapshot_heads_;
+
+    /**
+     * When we are currently reading from volatile list, the page we are currently in.
+     * Null otherwise.
+     */
+    SequentialPage*               volatile_cur_page_;
+  };
+
+  /// subroutines of next_batch().
+  ErrorCode next_batch_snapshot(SequentialRecordIterator* out, bool* found);
+  ErrorCode next_batch_safe_volatiles(SequentialRecordIterator* out, bool* found);
+  ErrorCode next_batch_unsafe_volatiles(SequentialRecordIterator* out, bool* found);
+
   thread::Thread* const               context_;
+  xct::Xct* const                     xct_;
+  Engine* const                       engine_;
   sequential::SequentialStorage const storage_;
   /**
    * Inclusive beginning of epochs to read.
    * @invariant !from_epoch_.is_valid()
    */
-  Epoch                         from_epoch_;
+  const Epoch                   from_epoch_;
   /**
    * Exclusive end of epochs to read.
    * @invariant !to_epoch_.is_valid()
    */
-  Epoch                         to_epoch_;
+  const Epoch                   to_epoch_;
 
-  uint16_t                      node_count_;
-  OrderMode                     order_mode_;
+  const Epoch                   latest_snapshot_epoch_;
+
+  const int32_t                 node_filter_;
+  const uint16_t                node_count_;
+  const OrderMode               order_mode_;
   /**
    * True when either the isolation level is SI, or to_epoch_ is up to the previous snapshot epoch.
    * When this is true, we just read snapshot pages without any concern on concurrency control.
@@ -133,12 +206,13 @@ class SequentialCursor {
    */
   bool                          safe_epoch_only_;
 
-  void* const                   buffer_;
+  SequentialRecordBatch* const  buffer_;
   const uint64_t                buffer_size_;
-  /** buffer_pages_ = buffer_size_ / 4kb */
+  /** buffer_pages_ = buffer_size_ / kPageSize */
   const uint32_t                buffer_pages_;
 
-  // everything above is const. Some of them doesn't have const qual due to init() method.
+  /// Everything above is const. Some of them doesn't have const qual due to init() method.
+  /// Everything below is mutable. in other words, they are the state of this cursor.
 
   /**
    * Index of the page in buffer_ we are now reading from.
@@ -156,22 +230,151 @@ class SequentialCursor {
    */
   uint16_t                      buffer_cur_record_;
 
-  /**
-   * Epoch of the record (page) we are currently reading.
-   */
-  Epoch                         cur_record_epoch_;
-
-  /** Number of tuples read so far. Just a statistics. */
-  uint64_t                      tuples_so_far_;
-
   uint16_t                      current_node_;
 
-  /** How far we have read from each node. Index is node ID. */
-  NodeState*                    states_;
+  /** whether this cursor has read all snapshot pages it should read. */
+  bool                          finished_snapshots_;
+  /** whether this cursor has read all volatile pages in safe epochs it should read. */
+  bool                          finished_safe_volatiles_;
+  /** whether this cursor has read all volatile pages in unsafe epochs it should read. */
+  bool                          finished_unsafe_volatiles_;
 
-  void init(OrderMode order_mode, Epoch from_epoch, Epoch to_epoch);
+  /** How far we have read from each node. Index is node ID. */
+  std::vector<NodeState>        states_;
 };
 
+
+/**
+ * @brief A chunk of records returned by SequentialCursor.
+ * @ingroup SEQUENTIAL
+ * @details
+ * SequentialCursor tends to return a huge number of records.
+ * For better performance, we return a page-full of records at a time.
+ *
+ * For now, as an optimization, this struct has the exact same format as SequentialPage,
+ * which is an internal implementation detail. On the other hand, this struct is an API.
+ * We keep them separate as the internal page representation might change in future.
+ */
+struct SequentialRecordBatch CXX11_FINAL {
+  PageHeader            header_;            // +32 -> 32
+
+  uint16_t              record_count_;      // +2 -> 34
+  uint16_t              used_data_bytes_;   // +2 -> 36
+  uint32_t              filler_;            // +4 -> 40
+
+  /**
+   * Pointer to next page.
+   * Once it is set, the pointer and the pointed page will never be changed.
+   */
+  DualPagePointer       next_page_;         // +16 -> 56
+
+  /**
+   * Dynamic data part in this page, which consist of 1) record part growing forward,
+   * 2) unused part, and 3) payload lengthes part growing backward.
+   */
+  char                  data_[kDataSize];
+
+
+  uint16_t       get_record_count() const { return record_count_; }
+  uint16_t       get_record_length(uint16_t index) const {
+    ASSERT_ND(index < record_count_);
+    return reinterpret_cast<const uint16_t*>(data_ + sizeof(data_))[-index - 1];
+  }
+  const xct::LockableXctId* get_xctid_from_offset(uint16_t offset) const {
+    ASSERT_ND(offset + record_count_ * sizeof(uint16_t) <= kDataSize);
+    return reinterpret_cast<const xct::LockableXctId*>(data_ + offset);
+  }
+  const char*    get_payload_from_offset(uint16_t offset) const {
+    ASSERT_ND(offset + record_count_ * sizeof(uint16_t) <= kDataSize);
+    return data_ + offset + sizeof(xct::LockableXctId);
+  }
+  Epoch          get_epoch_from_offset(uint16_t offset) const {
+    return get_xctid_from_offset(offset)->xct_id_.get_epoch();
+  }
+};
+
+/**
+ * @brief Iterator for one SequentialRecordBatch, or a page.
+ * @ingroup SEQUENTIAL
+ * @details
+ * This class inlines per-record methods, but not per-page methods (eg initialization).
+ */
+class SequentialRecordIterator CXX11_FINAL {
+ public:
+  SequentialRecordIterator();
+  SequentialRecordIterator(const SequentialRecordBatch* batch, Epoch from_epoch, Epoch to_epoch);
+
+  bool        is_valid() const ALWAYS_INLINE { return cur_record_ < record_count_; }
+  void        next() ALWAYS_INLINE {
+    while (true) {
+      if (UNLIKELY(cur_record_ + 1U >= record_count_)) {
+        cur_record_ = record_count_;
+        break;
+      }
+
+      ++cur_record_;
+      cur_offset_ += assorted::align8(cur_record_length_) + sizeof(xct::LockableXctId);
+      cur_record_length_ = batch_->get_record_length(cur_record_);
+      cur_record_epoch_ = batch_->get_epoch_from_offset(cur_offset_);
+      ASSERT_ND(cur_record_epoch_.is_valid());
+      if (LIKELY(in_epoch_range(cur_record_epoch_))) {
+        break;
+      }
+      // we have to skip this record
+      ++stat_skipped_records_;
+    }
+  }
+  uint16_t    get_cur_record_length() const ALWAYS_INLINE {
+    ASSERT_ND(is_valid());
+    return cur_record_length_;
+  }
+  Epoch       get_cur_record_epoch() const ALWAYS_INLINE {
+    ASSERT_ND(is_valid());
+    return cur_record_epoch_;
+  }
+  /**
+   * Copies the current record to the given buffer.
+   * This is safe even after the cursor moves on, but it incurs one memcpy.
+   * @see get_cur_record_raw()
+   */
+  void        copy_cur_record(char* out, uint16_t out_size) const ALWAYS_INLINE {
+    ASSERT_ND(is_valid());
+    const char* raw = get_cur_record_raw();
+    uint16_t copy_size = std::min<uint16_t>(out_size, cur_record_length_);
+    std::memcpy(out, raw, copy_size);
+  }
+  /**
+   * Directly returns a pointer to the current record. No memcpy, but note that the pointed address
+   * might become invalid once the cursor moves on. Use it with caution, like std::string::data().
+   * @see copy_cur_record()
+   */
+  const char* get_cur_record_raw() const ALWAYS_INLINE {
+    ASSERT_ND(is_valid());
+    return batch_->get_payload_from_offset(cur_offset_);
+  }
+  bool        in_epoch_range(Epoch epoch) const ALWAYS_INLINE {
+    return epoch >= from_epoch_ && epoch < to_epoch_;
+  }
+
+  /** @returns number of records we skipped so far due to from/to epoch */
+  uint16_t    get_stat_skipped_records() const { return stat_skipped_records_; }
+  /** @returns total number of records in this batch */
+  uint16_t    get_record_count() const { return record_count_; }
+
+ private:
+  const SequentialRecordBatch* batch_;  // +8 -> 8
+  Epoch     from_epoch_;                // +4 -> 12
+  Epoch     to_epoch_;                  // +4 -> 16
+  Epoch     cur_record_epoch_;          // +4 -> 20
+  uint16_t  record_count_;              // +2 -> 22
+  uint16_t  cur_record_;                // +2 -> 24
+  uint16_t  cur_record_length_;         // +2 -> 26
+  uint16_t  cur_offset_;                // +2 -> 28
+  uint16_t  stat_skipped_records_;      // +2 -> 30
+  uint16_t  filler_;                    // +2 -> 32
+};
+
+STATIC_SIZE_CHECK(sizeof(SequentialRecordBatch), kPageSize)
 
 }  // namespace sequential
 }  // namespace storage

--- a/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
@@ -198,7 +198,6 @@ class SequentialPage final {
    */
   char                  data_[kDataSize];
 };
-STATIC_SIZE_CHECK(sizeof(SequentialPage), 1 << 12)
 
 /**
  * @brief Represents one stable root page in \ref SEQUENTIAL.
@@ -232,12 +231,12 @@ class SequentialRootPage final {
 
   /** Returns How many pointers to head pages exist in this page. */
   uint16_t            get_pointer_count()  const { return pointer_count_; }
-  const SnapshotPagePointer* get_pointers() const { return head_page_pointers_; }
+  const HeadPagePointer* get_pointers() const { return head_page_pointers_; }
 
-  void set_pointers(SnapshotPagePointer *pointers, uint16_t pointer_count) {
+  void set_pointers(HeadPagePointer *pointers, uint16_t pointer_count) {
     ASSERT_ND(pointer_count <= kRootPageMaxHeadPointers);
     pointer_count_ = pointer_count;
-    std::memcpy(head_page_pointers_, pointers, sizeof(SnapshotPagePointer) * pointer_count);
+    std::memcpy(head_page_pointers_, pointers, sizeof(HeadPagePointer) * pointer_count);
   }
 
   SnapshotPagePointer get_next_page() const { return next_page_; }
@@ -263,8 +262,12 @@ class SequentialRootPage final {
   SnapshotPagePointer next_page_;       // +8 -> 48
 
   /** Pointers to heads of data pages. */
-  SnapshotPagePointer head_page_pointers_[kRootPageMaxHeadPointers];
+  HeadPagePointer     head_page_pointers_[kRootPageMaxHeadPointers];
+
+  char                filler_[kPageSize - kRootPageHeaderSize - sizeof(head_page_pointers_)];
 };
+
+STATIC_SIZE_CHECK(sizeof(SequentialPage), 1 << 12)
 STATIC_SIZE_CHECK(sizeof(SequentialRootPage), 1 << 12)
 
 }  // namespace sequential

--- a/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
@@ -112,6 +112,17 @@ class SequentialPage final {
       position += assorted::align8(payload_lengthes[i]) + foedus::storage::kRecordOverhead;
     }
   }
+  /** Returns beginning offset of the specified record */
+  uint16_t            get_record_offset(uint16_t record) const {
+    assert_consistent();
+    ASSERT_ND(record < get_record_count());
+    uint16_t offset = 0;
+    for (uint16_t i = 0; i < record; ++i) {
+      uint16_t payload_length = get_payload_length(i);
+      offset += assorted::align8(payload_length) + foedus::storage::kRecordOverhead;
+    }
+    return offset;
+  }
 
   DualPagePointer&        next_page() { return next_page_; }
   const DualPagePointer&  next_page() const { return next_page_; }
@@ -146,13 +157,19 @@ class SequentialPage final {
     ASSERT_ND(record < kMaxSlots);
     ASSERT_ND(used_data_bytes_ + assorted::align8(payload_length) + kRecordOverhead <= kDataSize);
     set_payload_length(record, payload_length);
-    xct::LockableXctId* owner_id_addr = reinterpret_cast<xct::LockableXctId*>(
-      data_ + used_data_bytes_);
+    xct::LockableXctId* owner_id_addr = owner_id_from_offset(used_data_bytes_);
     owner_id_addr->xct_id_ = owner_id;
     owner_id_addr->lock_.reset();  // not used...
     std::memcpy(data_ + used_data_bytes_ + kRecordOverhead, payload, payload_length);
     ++record_count_;
     used_data_bytes_ += assorted::align8(payload_length) + kRecordOverhead;
+    header_.key_count_ = record_count_;
+    if (!header_.snapshot_) {
+      // to protect concurrent cursor, version counter must be written at last
+      assorted::memory_fence_release();
+    }
+    // no need for lock to increment, just a barrier suffices. directly call status_.increment.
+    header_.page_version_.status_.increment_version_counter();
     assert_consistent();
   }
 
@@ -172,8 +189,15 @@ class SequentialPage final {
    */
   Epoch               get_first_record_epoch() const {
     ASSERT_ND(get_record_count() > 0);
-    const xct::LockableXctId* first_owner_id = reinterpret_cast<const xct::LockableXctId*>(data_);
+    const xct::LockableXctId* first_owner_id = owner_id_from_offset(0);
     return first_owner_id->xct_id_.get_epoch();
+  }
+
+  xct::LockableXctId* owner_id_from_offset(uint16_t offset) {
+    return reinterpret_cast<xct::LockableXctId*>(data_ + offset);
+  }
+  const xct::LockableXctId* owner_id_from_offset(uint16_t offset) const {
+    return reinterpret_cast<const xct::LockableXctId*>(data_ + offset);
   }
 
  private:

--- a/foedus-core/include/foedus/storage/sequential/sequential_storage_pimpl.hpp
+++ b/foedus-core/include/foedus/storage/sequential/sequential_storage_pimpl.hpp
@@ -96,8 +96,9 @@ struct SequentialStorageControlBlock final {
  *  \li Each thread maintains its own head/tail pages so that they don't interfere each other
  * at all. This, combined with the assumption above, makes it completely without blocking
  * and atomic operations \b EXCEPT:
- *  \li For scanning threads (which only rarely occur and are fundamentally slow anyways),
- * we take an exclusive lock. Further, the scanning thread must wait until all other threads
+ *  \li For scanning cursors (which only rarely occur and are fundamentally slow anyways),
+ * we take an exclusive lock when they touch \e unsafe epochs.
+ * Further, the scanning thread must wait until all other threads
  * did NOT start before the scanning thread take lock. (otherwise serializability is not
  * guaranteed). We will have something like Xct::InCommitEpochGuard for this purpose.
  * As scanning threads are rare, they can wait for a while, so it's okay for other threads

--- a/foedus-core/include/foedus/thread/thread.hpp
+++ b/foedus-core/include/foedus/thread/thread.hpp
@@ -147,6 +147,12 @@ class Thread CXX11_FINAL : public virtual Initializable {
    */
   ErrorCode     read_a_snapshot_page(storage::SnapshotPagePointer page_id, storage::Page* buffer);
 
+  /** Read contiguous pages in one shot. Other than that same as read_a_snapshot_page(). */
+  ErrorCode     read_snapshot_pages(
+    storage::SnapshotPagePointer page_id_begin,
+    uint32_t page_count,
+    storage::Page* buffer);
+
   /**
    * @brief Installs a volatile page to the given dual pointer as a copy of the snapshot page.
    * @param[in,out] pointer dual pointer. volatile pointer will be modified.

--- a/foedus-core/include/foedus/thread/thread_pimpl.hpp
+++ b/foedus-core/include/foedus/thread/thread_pimpl.hpp
@@ -173,6 +173,11 @@ class ThreadPimpl final : public DefaultInitializable {
   ErrorCode   read_a_snapshot_page(
     storage::SnapshotPagePointer page_id,
     storage::Page* buffer) ALWAYS_INLINE;
+  /** @copydoc foedus::thread::Thread::read_snapshot_pages() */
+  ErrorCode   read_snapshot_pages(
+    storage::SnapshotPagePointer page_id_begin,
+    uint32_t page_count,
+    storage::Page* buffer) ALWAYS_INLINE;
 
   /** @copydoc foedus::thread::Thread::install_a_volatile_page() */
   ErrorCode   install_a_volatile_page(
@@ -332,6 +337,12 @@ inline ErrorCode ThreadPimpl::read_a_snapshot_page(
   storage::SnapshotPagePointer page_id,
   storage::Page* buffer) {
   return snapshot_file_set_.read_page(page_id, buffer);
+}
+inline ErrorCode ThreadPimpl::read_snapshot_pages(
+  storage::SnapshotPagePointer page_id_begin,
+  uint32_t page_count,
+  storage::Page* buffer) {
+  return snapshot_file_set_.read_pages(page_id_begin, page_count, buffer);
 }
 
 static_assert(

--- a/foedus-core/include/foedus/xct/namespace-info.hpp
+++ b/foedus-core/include/foedus/xct/namespace-info.hpp
@@ -85,7 +85,7 @@
  * In many cases, the invariants are trivially achieved. However, there are a few tricky cases.
  *  \li There is a long running transaction that already acquired a commit-epoch but not yet
  * exit from the pre-commit stage.
- *  \li Three is a worker thread that has been idle for a while.
+ *  \li There is a worker thread that has been idle for a while.
  *
  * Whenever the chime advances the epoch, we have to safely detect whether there is any transaction
  * that might violate the invariant \b without causing expensive synchronization.

--- a/foedus-core/include/foedus/xct/xct_manager.hpp
+++ b/foedus-core/include/foedus/xct/xct_manager.hpp
@@ -47,10 +47,17 @@ class XctManager CXX11_FINAL : public virtual Initializable {
   ErrorStack  uninitialize() CXX11_OVERRIDE;
 
   /**
-   * @brief Returns the current global epoch.
+   * @brief Returns the current global epoch, the epoch a newly started transaction will be in.
    */
   Epoch       get_current_global_epoch() const;
   Epoch       get_current_global_epoch_weak() const;
+
+  /**
+   * @brief Returns the current grace-period epoch (global epoch - 1), the epoch
+   * \e some transaction might be still in (though rare).
+   */
+  Epoch       get_current_grace_epoch() const;
+  Epoch       get_current_grace_epoch_weak() const;
 
   /** Passively wait until the current global epoch becomes the given value. */
   void        wait_for_current_global_epoch(Epoch target_epoch, int64_t wait_microseconds = -1);

--- a/foedus-core/src/foedus/cache/cache_manager_pimpl.cpp
+++ b/foedus-core/src/foedus/cache/cache_manager_pimpl.cpp
@@ -121,7 +121,7 @@ void CacheManagerPimpl::handle_cleaner() {
 
   const uint32_t kIntervalMs = 5;  // should be a bit shorter than epoch-advance interval
   while (!stop_requested_) {
-    DVLOG(1) << "Cleaner thread came in: " << describe();
+    DVLOG(2) << "Cleaner thread came in: " << describe();
     ASSERT_ND(reclaimed_pages_count_ == 0);
     assorted::memory_fence_acquire();
     memory::PagePool::Stat stat = pool_->get_stat();
@@ -176,7 +176,7 @@ void CacheManagerPimpl::handle_cleaner() {
           " that the cleaner thread is getting behind or the pool is too small: " << describe();
       }
     } else {
-      DVLOG(1) << "Still enough free pages. do nothing";
+      DVLOG(2) << "Still enough free pages. do nothing";
     }
 
     if (!stop_requested_) {

--- a/foedus-core/src/foedus/memory/engine_memory.cpp
+++ b/foedus-core/src/foedus/memory/engine_memory.cpp
@@ -33,6 +33,7 @@
 #include "foedus/cache/snapshot_file_set.hpp"
 #include "foedus/debugging/debugging_supports.hpp"
 #include "foedus/memory/numa_node_memory.hpp"
+#include "foedus/soc/soc_manager.hpp"
 #include "foedus/storage/page.hpp"
 #include "foedus/storage/storage_id.hpp"
 #include "foedus/thread/thread_id.hpp"
@@ -97,6 +98,14 @@ ErrorStack EngineMemory::uninitialize_once() {
     LOG(INFO) << "Node memory-" << node << " was uninitialized!";
   }
   return SUMMARIZE_ERROR_BATCH(batch);
+}
+
+void* EngineMemory::get_shared_user_memory() const {
+  return engine_->get_soc_manager()->get_shared_user_memory();
+}
+
+uint64_t EngineMemory::get_shared_user_memory_size() const {
+  return engine_->get_soc_manager()->get_shared_user_memory_size();
 }
 
 std::string EngineMemory::dump_free_memory_stat() const {

--- a/foedus-core/src/foedus/savepoint/savepoint.cpp
+++ b/foedus-core/src/foedus/savepoint/savepoint.cpp
@@ -73,6 +73,7 @@ ErrorStack Savepoint::save(tinyxml2::XMLElement* element) const {
 void Savepoint::populate_empty(log::LoggerId logger_count) {
   current_epoch_ = Epoch::kEpochInitialCurrent;
   durable_epoch_ = Epoch::kEpochInitialDurable;
+  earliest_epoch_ = Epoch::kEpochInitialDurable;
   latest_snapshot_id_ = snapshot::kNullSnapshotId;
   latest_snapshot_epoch_ = Epoch::kEpochInvalid;
   meta_log_oldest_offset_ = 0;

--- a/foedus-core/src/foedus/savepoint/savepoint_manager.cpp
+++ b/foedus-core/src/foedus/savepoint/savepoint_manager.cpp
@@ -39,6 +39,10 @@ Epoch SavepointManager::get_initial_current_epoch() const {
 Epoch SavepointManager::get_initial_durable_epoch() const {
   return pimpl_->get_initial_durable_epoch();
 }
+Epoch SavepointManager::get_earliest_epoch() const {
+  return pimpl_->get_earliest_epoch();
+}
+
 Epoch SavepointManager::get_saved_durable_epoch() const {
   return pimpl_->get_saved_durable_epoch();
 }

--- a/foedus-core/src/foedus/savepoint/savepoint_manager_pimpl.cpp
+++ b/foedus-core/src/foedus/savepoint/savepoint_manager_pimpl.cpp
@@ -61,6 +61,7 @@ ErrorStack SavepointManagerPimpl::initialize_once() {
     update_shared_savepoint(savepoint_);
     control_block_->initial_current_epoch_ = savepoint_.current_epoch_;
     control_block_->initial_durable_epoch_ = savepoint_.durable_epoch_;
+    control_block_->earliest_epoch_ = savepoint_.earliest_epoch_;
     control_block_->saved_durable_epoch_ = savepoint_.durable_epoch_;
     control_block_->requested_durable_epoch_ = savepoint_.durable_epoch_;
     savepoint_thread_stop_requested_ = false;

--- a/foedus-core/src/foedus/snapshot/snapshot_manager.cpp
+++ b/foedus-core/src/foedus/snapshot/snapshot_manager.cpp
@@ -49,8 +49,10 @@ ErrorStack SnapshotManager::read_snapshot_metadata(SnapshotId snapshot_id, Snaps
 }
 
 
-void SnapshotManager::trigger_snapshot_immediate(bool wait_completion) {
-  pimpl_->trigger_snapshot_immediate(wait_completion);
+void SnapshotManager::trigger_snapshot_immediate(
+  bool wait_completion,
+  Epoch suggested_snapshot_epoch) {
+  pimpl_->trigger_snapshot_immediate(wait_completion, suggested_snapshot_epoch);
 }
 
 }  // namespace snapshot

--- a/foedus-core/src/foedus/soc/soc_manager.cpp
+++ b/foedus-core/src/foedus/soc/soc_manager.cpp
@@ -37,6 +37,14 @@ ErrorStack  SocManager::uninitialize() { return pimpl_->uninitialize(); }
 
 SharedMemoryRepo* SocManager::get_shared_memory_repo() { return &pimpl_->memory_repo_; }
 
+void* SocManager::get_shared_user_memory() const {
+  return pimpl_->memory_repo_.get_global_user_memory();
+}
+uint64_t SocManager::get_shared_user_memory_size() const {
+  return pimpl_->engine_->get_options().soc_.shared_user_memory_size_kb_ * 1024ULL;
+}
+
+
 void SocManager::trap_spawned_soc_main() {
   std::vector< proc::ProcAndName > procedures;
   trap_spawned_soc_main(procedures);

--- a/foedus-core/src/foedus/storage/sequential/CMakeLists.txt
+++ b/foedus-core/src/foedus/storage/sequential/CMakeLists.txt
@@ -1,5 +1,6 @@
 set_property(GLOBAL APPEND PROPERTY ALL_FOEDUS_CORE_SRC
   ${CMAKE_CURRENT_SOURCE_DIR}/sequential_composer_impl.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/sequential_cursor.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sequential_log_types.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sequential_metadata.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/sequential_page_impl.cpp

--- a/foedus-core/src/foedus/storage/sequential/sequential_composer_impl.cpp
+++ b/foedus-core/src/foedus/storage/sequential/sequential_composer_impl.cpp
@@ -362,7 +362,7 @@ Composer::DropResult SequentialComposer::drop_volatiles(
         } else {
           // move head
           *head_ptr = next;
-          DVLOG(1) << "Thread-" << thread_id << " in sequential-" << storage_id_ << " dropped a"
+          DVLOG(2) << "Thread-" << thread_id << " in sequential-" << storage_id_ << " dropped a"
             << " page.";
         }
       }

--- a/foedus-core/src/foedus/storage/sequential/sequential_cursor.cpp
+++ b/foedus-core/src/foedus/storage/sequential/sequential_cursor.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2014-2015, Hewlett-Packard Development Company, LP.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details. You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * HP designates this particular file as subject to the "Classpath" exception
+ * as provided by HP in the LICENSE.txt file that accompanied this code.
+ */
+#include "foedus/storage/sequential/sequential_cursor.hpp"
+
+#include <glog/logging.h>
+
+#include <ostream>
+
+#include "foedus/assert_nd.hpp"
+#include "foedus/engine.hpp"
+#include "foedus/savepoint/savepoint_manager.hpp"
+#include "foedus/snapshot/snapshot_manager.hpp"
+#include "foedus/thread/thread.hpp"
+#include "foedus/xct/xct.hpp"
+#include "foedus/xct/xct_manager.hpp"
+
+namespace foedus {
+namespace storage {
+namespace sequential {
+
+SequentialCursor::SequentialCursor(
+  thread::Thread* context,
+  const SequentialStorage& storage,
+  void* buffer,
+  uint64_t buffer_size,
+  OrderMode order_mode,
+  Epoch from_epoch,
+  Epoch to_epoch,
+  int32_t node_filter)
+  : context_(context),
+    xct_(&context->get_current_xct()),
+    engine_(context->get_engine()),
+    storage_(storage),
+    from_epoch_(
+      from_epoch.is_valid() ? from_epoch : engine_->get_savepoint_manager()->get_earliest_epoch()),
+    to_epoch_(
+      to_epoch.is_valid() ? to_epoch : engine_->get_xct_manager()->get_current_global_epoch()),
+    latest_snapshot_epoch_(engine_->get_snapshot_manager()->get_snapshot_epoch()),
+    node_filter_(node_filter),
+    node_count_(engine_->get_soc_count()),
+    order_mode_(order_mode),
+    buffer_(reinterpret_cast<SequentialRecordBatch*>(buffer)),
+    buffer_size_(buffer_size),
+    buffer_pages_(buffer_size / kPageSize) {
+  buffer_cur_page_ = 0;
+  buffer_cur_page_records_ = 0;
+  buffer_cur_record_ = 0;
+  current_node_ = 0;
+  finished_snapshots_ = false;
+  finished_safe_volatiles_ = false;
+  finished_unsafe_volatiles_ = false;
+  for (uint16_t i = 0; i < node_count_; ++i) {
+    states_.emplace_back(i);
+  }
+
+  Epoch current_global_epoch = engine_->get_xct_manager()->get_current_global_epoch();
+  ASSERT_ND(from_epoch_.is_valid());
+  ASSERT_ND(to_epoch_.is_valid());
+  ASSERT_ND(from_epoch_ <= to_epoch_);
+
+  if (context_->get_current_xct().get_isolation_level() == xct::kSnapshot
+    || (latest_snapshot_epoch_.is_valid() && to_epoch_ <= latest_snapshot_epoch_)) {
+    snapshot_only_ = true;
+    safe_epoch_only_ = true;
+    finished_safe_volatiles_ = true;
+    finished_unsafe_volatiles_ = true;
+  } else {
+    snapshot_only_ = false;
+    if (to_epoch_ <= current_global_epoch) {
+      safe_epoch_only_ = true;
+      finished_unsafe_volatiles_ = true;
+    } else {
+      // only in this case, we have to take a lock
+      safe_epoch_only_ = false;
+    }
+  }
+}
+
+SequentialCursor::~SequentialCursor() {
+  states_.clear();
+}
+
+SequentialCursor::NodeState::NodeState(uint16_t node_id) : node_id_(node_id) {
+  snapshot_cur_head_ = 0;
+  snapshot_cur_head_read_pages_ = 0;
+  volatile_cur_page_ = nullptr;
+}
+SequentialCursor::NodeState::~NodeState() {}
+
+SequentialRecordIterator::SequentialRecordIterator()
+  : batch_(nullptr),
+    from_epoch_(INVALID_EPOCH),
+    to_epoch_(INVALID_EPOCH),
+    record_count_(0) {
+  cur_record_ = 0;
+  cur_record_length_ = 0;
+  cur_offset_ = 0;
+  cur_record_epoch_ = INVALID_EPOCH;
+  stat_skipped_records_ = 0;
+}
+
+SequentialRecordIterator::SequentialRecordIterator(
+  const SequentialRecordBatch* batch,
+  Epoch from_epoch,
+  Epoch to_epoch)
+  : batch_(batch),
+    from_epoch_(from_epoch),
+    to_epoch_(to_epoch),
+    record_count_(batch->get_record_count()) {
+  cur_record_ = 0;
+  cur_record_length_ = batch_->get_record_length(0);
+  cur_offset_ = 0;
+  cur_record_epoch_ = batch->get_epoch_from_offset(0);
+  ASSERT_ND(cur_record_epoch_.is_valid());
+  stat_skipped_records_ = 0;
+  if (!in_epoch_range(cur_record_epoch_)) {
+    ++stat_skipped_records_;
+    next();
+  }
+}
+
+ErrorCode SequentialCursor::next_batch(SequentialRecordIterator* out) {
+  bool found = false;
+  if (!finished_snapshots_) {
+    CHECK_ERROR_CODE(next_batch_snapshot(out, &found));
+    if (found) {
+      return kErrorCodeOk;
+    } else {
+      DVLOG(1) << "Finished reading snapshot pages:" << *this;
+      finished_snapshots_ = true;
+    }
+  }
+
+  if (!finished_safe_volatiles_) {
+    CHECK_ERROR_CODE(next_batch_safe_volatiles(out, &found));
+    if (found) {
+      return kErrorCodeOk;
+    } else {
+      DVLOG(1) << "Finished reading safe volatile pages:" << *this;
+      finished_safe_volatiles_ = true;
+    }
+  }
+
+  if (!finished_unsafe_volatiles_) {
+    CHECK_ERROR_CODE(next_batch_unsafe_volatiles(out, &found));
+    if (found) {
+      return kErrorCodeOk;
+    } else {
+      DVLOG(1) << "Finished reading unsafe volatile pages:" << *this;
+      finished_unsafe_volatiles_ = true;
+    }
+  }
+
+  ASSERT_ND(!is_valid());
+
+  return kErrorCodeOk;
+}
+
+ErrorCode SequentialCursor::next_batch_snapshot(
+  SequentialRecordIterator* /*out*/,
+  bool* /*found*/) {
+  // TODO(Hideaki) implement
+  return kErrorCodeOk;
+}
+
+ErrorCode SequentialCursor::next_batch_safe_volatiles(
+  SequentialRecordIterator* /*out*/,
+  bool* /*found*/) {
+  // TODO(Hideaki) implement
+  return kErrorCodeOk;
+}
+
+ErrorCode SequentialCursor::next_batch_unsafe_volatiles(
+  SequentialRecordIterator* /*out*/,
+  bool* /*found*/) {
+  // TODO(Hideaki) implement
+  return kErrorCodeOk;
+}
+
+std::ostream& operator<<(std::ostream& o, const SequentialCursor& /*v*/) {
+  o << "<SequentialCursor>";
+  // TODO(Hideaki) implement
+  o << "</SequentialCursor>";
+  return o;
+}
+
+
+}  // namespace sequential
+}  // namespace storage
+}  // namespace foedus

--- a/foedus-core/src/foedus/storage/sequential/sequential_cursor.cpp
+++ b/foedus-core/src/foedus/storage/sequential/sequential_cursor.cpp
@@ -19,12 +19,15 @@
 
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <ostream>
 
 #include "foedus/assert_nd.hpp"
 #include "foedus/engine.hpp"
 #include "foedus/savepoint/savepoint_manager.hpp"
 #include "foedus/snapshot/snapshot_manager.hpp"
+#include "foedus/storage/sequential/sequential_page_impl.hpp"
+#include "foedus/storage/sequential/sequential_storage_pimpl.hpp"
 #include "foedus/thread/thread.hpp"
 #include "foedus/xct/xct.hpp"
 #include "foedus/xct/xct_manager.hpp"
@@ -45,11 +48,12 @@ SequentialCursor::SequentialCursor(
   : context_(context),
     xct_(&context->get_current_xct()),
     engine_(context->get_engine()),
+    resolver_(engine_->get_memory_manager()->get_global_volatile_page_resolver()),
     storage_(storage),
     from_epoch_(
       from_epoch.is_valid() ? from_epoch : engine_->get_savepoint_manager()->get_earliest_epoch()),
     to_epoch_(
-      to_epoch.is_valid() ? to_epoch : engine_->get_xct_manager()->get_current_global_epoch()),
+      to_epoch.is_valid() ? to_epoch : engine_->get_xct_manager()->get_current_grace_epoch()),
     latest_snapshot_epoch_(engine_->get_snapshot_manager()->get_snapshot_epoch()),
     node_filter_(node_filter),
     node_count_(engine_->get_soc_count()),
@@ -57,23 +61,19 @@ SequentialCursor::SequentialCursor(
     buffer_(reinterpret_cast<SequentialRecordBatch*>(buffer)),
     buffer_size_(buffer_size),
     buffer_pages_(buffer_size / kPageSize) {
-  buffer_cur_page_ = 0;
-  buffer_cur_page_records_ = 0;
-  buffer_cur_record_ = 0;
+  ASSERT_ND(buffer_size >= kPageSize);
   current_node_ = 0;
   finished_snapshots_ = false;
   finished_safe_volatiles_ = false;
   finished_unsafe_volatiles_ = false;
-  for (uint16_t i = 0; i < node_count_; ++i) {
-    states_.emplace_back(i);
-  }
+  states_.clear();
 
-  Epoch current_global_epoch = engine_->get_xct_manager()->get_current_global_epoch();
+  Epoch grace_epoch = engine_->get_xct_manager()->get_current_grace_epoch();
   ASSERT_ND(from_epoch_.is_valid());
   ASSERT_ND(to_epoch_.is_valid());
   ASSERT_ND(from_epoch_ <= to_epoch_);
 
-  if (context_->get_current_xct().get_isolation_level() == xct::kSnapshot
+  if (xct_->get_isolation_level() == xct::kSnapshot
     || (latest_snapshot_epoch_.is_valid() && to_epoch_ <= latest_snapshot_epoch_)) {
     snapshot_only_ = true;
     safe_epoch_only_ = true;
@@ -81,7 +81,7 @@ SequentialCursor::SequentialCursor(
     finished_unsafe_volatiles_ = true;
   } else {
     snapshot_only_ = false;
-    if (to_epoch_ <= current_global_epoch) {
+    if (to_epoch_ <= grace_epoch) {
       safe_epoch_only_ = true;
       finished_unsafe_volatiles_ = true;
     } else {
@@ -96,9 +96,11 @@ SequentialCursor::~SequentialCursor() {
 }
 
 SequentialCursor::NodeState::NodeState(uint16_t node_id) : node_id_(node_id) {
+  volatile_cur_core_ = 0;
   snapshot_cur_head_ = 0;
-  snapshot_cur_head_read_pages_ = 0;
-  volatile_cur_page_ = nullptr;
+  snapshot_cur_buffer_ = 0;
+  snapshot_buffered_pages_ = 0;
+  snapshot_buffer_begin_ = 0;
 }
 SequentialCursor::NodeState::~NodeState() {}
 
@@ -135,6 +137,11 @@ SequentialRecordIterator::SequentialRecordIterator(
 }
 
 ErrorCode SequentialCursor::next_batch(SequentialRecordIterator* out) {
+  out->reset();
+  if (states_.empty()) {
+    CHECK_ERROR_CODE(init_states());
+  }
+
   bool found = false;
   if (!finished_snapshots_) {
     CHECK_ERROR_CODE(next_batch_snapshot(out, &found));
@@ -167,34 +174,380 @@ ErrorCode SequentialCursor::next_batch(SequentialRecordIterator* out) {
   }
 
   ASSERT_ND(!is_valid());
+  return kErrorCodeOk;
+}
 
+ErrorCode SequentialCursor::init_states() {
+  DVLOG(0) << "Initializing states..." << *this;
+  for (uint16_t node_id = 0; node_id < node_count_; ++node_id) {
+    states_.emplace_back(node_id);
+  }
+
+  // initialize snapshot page status
+  if (finished_snapshots_) {
+    ASSERT_ND(!latest_snapshot_epoch_.is_valid());
+  } else {
+    ASSERT_ND(latest_snapshot_epoch_.is_valid());
+    SnapshotPagePointer root_snapshot_page_id = storage_.get_metadata()->root_snapshot_page_id_;
+
+    // read all entries from all root pages
+    uint64_t too_old_pointers = 0;
+    uint64_t too_new_pointers = 0;
+    uint64_t added_pointers = 0;
+    uint32_t page_count = 0;
+    for (SnapshotPagePointer next_page_id = root_snapshot_page_id; next_page_id != 0;) {
+      ASSERT_ND(next_page_id != 0);
+      ++page_count;
+      SequentialRootPage* page;
+      CHECK_ERROR_CODE(context_->find_or_read_a_snapshot_page(
+        next_page_id,
+        reinterpret_cast<Page**>(&page)));
+      for (uint16_t i = 0; i < page->get_pointer_count(); ++i) {
+        const HeadPagePointer& pointer = page->get_pointers()[i];
+        ASSERT_ND(pointer.from_epoch_.is_valid());
+        ASSERT_ND(pointer.to_epoch_.is_valid());
+        if (pointer.to_epoch_ >= from_epoch_) {
+          ++too_new_pointers;
+          continue;
+        } else if (pointer.from_epoch_ <= to_epoch_) {
+          ++too_old_pointers;
+          continue;
+        } else {
+          ++added_pointers;
+          uint16_t node_id = extract_numa_node_from_snapshot_pointer(pointer.page_id_);
+          ASSERT_ND(node_id < node_count_);
+          states_[node_id].snapshot_heads_.push_back(pointer);
+        }
+      }
+      next_page_id = page->get_next_page();
+    }
+
+    DVLOG(0) << "Read " << page_count << " root snapshot pages. added_pointers=" << added_pointers
+      << ", too_old_pointers=" << too_old_pointers << ", too_new_pointers=" << too_new_pointers;
+    if (added_pointers == 0) {
+      finished_snapshots_ = true;
+    }
+  }
+
+  // initialize volatile page status
+  if (finished_safe_volatiles_ && finished_unsafe_volatiles_) {
+    ASSERT_ND(safe_epoch_only_);
+  } else {
+    SequentialStoragePimpl pimpl(engine_, storage_.get_control_block());
+    uint16_t thread_per_node = engine_->get_options().thread_.thread_count_per_group_;
+
+    uint64_t empty_threads = 0;
+    for (uint16_t node_id = 0; node_id < node_count_; ++node_id) {
+      NodeState& state = states_[node_id];
+      for (uint16_t thread_ordinal = 0; thread_ordinal < thread_per_node; ++thread_ordinal) {
+        thread::ThreadId thread_id = thread::compose_thread_id(node_id, thread_ordinal);
+        memory::PagePoolOffset offset = *pimpl.get_head_pointer(thread_id);
+        if (offset == 0) {
+          // TASK(Hideaki) This should install the head pointer to not overlook concurrent
+          // insertions. Currently we will miss records in such a case. We need
+          // a lock for head-installation. Overhead is not an issue because this rarely happens,
+          // but we need to implement. later later.
+          ++empty_threads;
+          state.volatile_cur_pages_.push_back(nullptr);
+          continue;
+        }
+        VolatilePagePointer pointer = combine_volatile_page_pointer(node_id, 0, 0, offset);
+        SequentialPage* page = resolve_volatile(pointer);
+        if (page->get_record_count() > 0 && page->get_first_record_epoch() >= to_epoch_) {
+          // even the first record has too-new epoch, no chance. safe to ignore this thread.
+          ++empty_threads;
+          state.volatile_cur_pages_.push_back(nullptr);
+          continue;
+        }
+
+        // from_epoch_ doesn't matter. the thread might be inserting a new record right now.
+        state.volatile_cur_pages_.push_back(page);
+      }
+      ASSERT_ND(state.volatile_cur_pages_.size() == thread_per_node);
+    }
+    DVLOG(0) << "Initialized volatile head pages. empty_threads=" << empty_threads;
+  }
+
+  DVLOG(0) << "Initialized states." << *this;
   return kErrorCodeOk;
 }
 
 ErrorCode SequentialCursor::next_batch_snapshot(
-  SequentialRecordIterator* /*out*/,
-  bool* /*found*/) {
-  // TODO(Hideaki) implement
+  SequentialRecordIterator* out,
+  bool* found) {
+  ASSERT_ND(!finished_snapshots_);
+  ASSERT_ND(order_mode_ == kNodeFirstMode);  // TASK(Hideaki) implement other modes
+  // When we implement epoch_first mode, remember that we have to split the buffer to nodes.
+  // In the worst case we have to read one-page at a time...
+  // The code below assumed node-first mode, so we can fully use the buffer for each node.
+  while (current_node_ < node_count_) {
+    NodeState& state = states_[current_node_];
+    if (state.snapshot_cur_buffer_ >= state.snapshot_buffered_pages_) {
+      // need to buffer more
+      CHECK_ERROR_CODE(buffer_snapshot_pages(current_node_));
+      if (state.snapshot_cur_buffer_ >= state.snapshot_buffered_pages_) {
+        ++current_node_;
+        continue;
+      }
+    }
+
+    // okay, we have a page to return
+    ASSERT_ND(state.snapshot_cur_buffer_ < state.snapshot_buffered_pages_);
+    *out = SequentialRecordIterator(buffer_ + state.snapshot_cur_buffer_, from_epoch_, to_epoch_);
+    *found = true;
+    ++state.snapshot_cur_buffer_;
+    return kErrorCodeOk;
+  }
+
+  ASSERT_ND(*found == false);
+  finished_snapshots_ = true;
+  current_node_ = 0;
+  DVLOG(0) << "Finished reading snapshot pages: " << *this;
+  return kErrorCodeOk;
+}
+
+ErrorCode SequentialCursor::buffer_snapshot_pages(uint16_t node) {
+  NodeState& state = states_[current_node_];
+  ASSERT_ND(state.snapshot_cur_head_ < state.snapshot_heads_.size());
+
+  // do we have to switch to next linked-list?
+  while (state.snapshot_buffer_begin_ + state.snapshot_cur_buffer_
+      >= state.get_cur_head().page_count_) {
+    DVLOG(1) << "Completed node-" << node << "'s head-"
+      << state.snapshot_cur_head_ << ": " << *this;
+    ++state.snapshot_cur_head_;
+    state.snapshot_cur_buffer_ = 0;
+    state.snapshot_buffer_begin_ = 0;
+    state.snapshot_buffered_pages_ = 0;
+    if (state.snapshot_cur_head_ == state.snapshot_heads_.size()) {
+      DVLOG(1) << "Completed node-" << node << "'s all heads: " << *this;
+      return kErrorCodeOk;
+    }
+  }
+
+  const HeadPagePointer& head = state.get_cur_head();
+  ASSERT_ND(state.snapshot_cur_buffer_ == state.snapshot_buffered_pages_);
+  ASSERT_ND(state.snapshot_buffer_begin_ + state.snapshot_cur_buffer_ < head.page_count_);
+  uint32_t remaining = head.page_count_ - state.snapshot_buffer_begin_ - state.snapshot_cur_buffer_;
+  uint32_t to_read = std::min<uint32_t>(buffer_pages_, remaining);
+  ASSERT_ND(to_read > 0);
+  DVLOG(1) << "Buffering " << to_read << " pages. " << *this;
+
+  // here, we read contiguous to_read pages in one shot.
+  // this means that we always bypass snapshot-cache, but shouldn't be
+  // an issue considering that we are probably reading millions of pages.
+  uint32_t new_begin = state.snapshot_buffer_begin_ + state.snapshot_cur_buffer_;
+  SnapshotPagePointer page_id_begin = head.page_id_ + new_begin;
+  CHECK_ERROR_CODE(
+    context_->read_snapshot_pages(page_id_begin, to_read, reinterpret_cast<Page*>(buffer_)));
+  state.snapshot_buffer_begin_ = new_begin;
+  state.snapshot_cur_buffer_ = 0;
+  state.snapshot_buffered_pages_ = to_read;
+
+#ifndef NDEBUG
+  // sanity checks
+  for (uint32_t i = 0; i < to_read; ++i) {
+    const SequentialRecordBatch* p = buffer_ + i;
+    ASSERT_ND(p->header_.page_id_ == page_id_begin + i);
+    ASSERT_ND(p->header_.snapshot_);
+    ASSERT_ND(p->header_.get_page_type() == kSequentialPageType);
+    ASSERT_ND(p->next_page_.volatile_pointer_.is_null());
+    if (i + state.snapshot_buffer_begin_ == head.page_count_) {
+      ASSERT_ND(p->next_page_.snapshot_pointer_ == 0);
+    } else {
+      ASSERT_ND(p->next_page_.snapshot_pointer_ == page_id_begin + i + 1U);
+    }
+  }
+#endif  // NDEBUG
   return kErrorCodeOk;
 }
 
 ErrorCode SequentialCursor::next_batch_safe_volatiles(
-  SequentialRecordIterator* /*out*/,
-  bool* /*found*/) {
-  // TODO(Hideaki) implement
+  SequentialRecordIterator* out,
+  bool* found) {
+  ASSERT_ND(!finished_safe_volatiles_);
+  ASSERT_ND(order_mode_ == kNodeFirstMode);  // TASK(Hideaki) implement other modes
+  Epoch grace_epoch = engine_->get_xct_manager()->get_current_grace_epoch();
+  while (current_node_ < node_count_) {
+    NodeState& state = states_[current_node_];
+    while (state.volatile_cur_core_ < state.volatile_cur_pages_.size()) {
+      SequentialPage* page = state.volatile_cur_pages_[state.volatile_cur_core_];
+      if (page == nullptr) {
+        DVLOG(1) << "Skipped empty core. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ".: " << *this;
+        ++state.volatile_cur_core_;
+        break;
+      }
+      // Even if we have a volatile page, is it safe to read from?
+      // If not, we skip reading here and will resume in the unsafe part.
+      VolatilePagePointer next_pointer = page->next_page().volatile_pointer_;
+      if (next_pointer.is_null()) {
+        // Tail page is always unsafe. We don't know when next-pointer will be installed.
+        DVLOG(1) << "Skipped tail page. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ".: " << *this;
+        ++state.volatile_cur_core_;
+        break;
+      }
+
+      if (page->get_record_count() == 0) {
+        // if it's not the tail, even an empty page (which should be rare) is safe.
+        // we just move on to next page
+        LOG(INFO) << "Interesting. Empty non-tail page. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ". page= " << page->header();
+        SequentialPage* next_page = resolve_volatile(next_pointer);
+        state.volatile_cur_pages_[state.volatile_cur_core_] = next_page;
+        continue;  // move on to next
+      }
+
+      // All records in this page have this epoch.
+      Epoch epoch = page->get_first_record_epoch();
+      if (epoch >= to_epoch_) {
+        DVLOG(1) << "Reached to_epoch. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ".: " << *this;
+        ++state.volatile_cur_core_;
+        break;
+      } else if (epoch >= grace_epoch) {
+        DVLOG(1) << "Reached unsafe page. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ".: " << *this;
+        ++state.volatile_cur_core_;
+        break;
+      }
+
+      // okay, this page is safe to read!
+      if (epoch < from_epoch_) {
+        DVLOG(2) << "Skipping too-old epoch. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ".: " << *this;
+        SequentialPage* next_page = resolve_volatile(next_pointer);
+        state.volatile_cur_pages_[state.volatile_cur_core_] = next_page;
+        continue;  // move on to next
+      }
+
+      // okay, safe and not too old.
+      *out = SequentialRecordIterator(
+        reinterpret_cast<SequentialRecordBatch*>(page),
+        from_epoch_,
+        to_epoch_);
+      *found = true;
+      SequentialPage* next_page = resolve_volatile(next_pointer);
+      state.volatile_cur_pages_[state.volatile_cur_core_] = next_page;
+      return kErrorCodeOk;
+    }
+
+    DVLOG(0) << "Finished reading all safe epochs in node-" << current_node_ << ": " << *this;
+    ++current_node_;
+  }
+
+  ASSERT_ND(*found == false);
+  finished_safe_volatiles_ = true;
+  current_node_ = 0;
+  DVLOG(0) << "Finished reading safe volatile pages: " << *this;
   return kErrorCodeOk;
 }
 
 ErrorCode SequentialCursor::next_batch_unsafe_volatiles(
-  SequentialRecordIterator* /*out*/,
-  bool* /*found*/) {
-  // TODO(Hideaki) implement
+  SequentialRecordIterator* out,
+  bool* found) {
+  ASSERT_ND(!finished_unsafe_volatiles_);
+  // mode doesn't matter when we are reading unsafe epochs. we just read them all one by one.
+
+
+  Epoch grace_epoch = engine_->get_xct_manager()->get_current_grace_epoch();
+
+  // if the record is in current global epoch, we have to take it as read-set for serializability.
+  // records in grace epoch are fine. This transaction will be surely in the current global epoch
+  // or later, so the dependency is trivially met.
+  bool serializable = xct_->get_isolation_level() == xct::kSerializable;
+  while (current_node_ < node_count_) {
+    NodeState& state = states_[current_node_];
+    while (state.volatile_cur_core_ < state.volatile_cur_pages_.size()) {
+      SequentialPage* page = state.volatile_cur_pages_[state.volatile_cur_core_];
+      if (page == nullptr) {
+        DVLOG(1) << "Skipped empty core. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ".: " << *this;
+        ++state.volatile_cur_core_;
+        break;
+      }
+
+      ASSERT_ND(page->get_record_count() > 0);
+      Epoch epoch = page->get_first_record_epoch();
+      if (epoch >= to_epoch_) {
+        DVLOG(1) << "Reached to_epoch. node=" << current_node_ << ", core="
+          << state.volatile_cur_core_ << ".: " << *this;
+        ++state.volatile_cur_core_;
+        break;
+      }
+
+      VolatilePagePointer next_pointer = page->next_page().volatile_pointer_;
+      bool tail_page = next_pointer.is_null();
+      uint16_t record_count = page->get_record_count();
+      if (serializable) {
+        // let's protect the above two information with page version
+        assorted::memory_fence_consume();
+        PageVersionStatus observed = page->header().page_version_.status_;
+        assorted::memory_fence_consume();
+        if ((tail_page && !page->next_page().volatile_pointer_.is_null())
+            || page->get_record_count() != record_count) {
+          LOG(INFO) << "Wow, super rare. just installed next page or added a new record!";
+          continue;  // retry. concurrent thread has now installed it!
+        }
+
+        // If not tail page, this page is already safe.
+        // Otherwise, we have to protect the fact that this was a tail page by
+        // taking a page-version set if the transaction is serializable.
+        if (tail_page) {
+          CHECK_ERROR_CODE(xct_->add_to_page_version_set(&page->header().page_version_, observed));
+        }
+      }
+
+      // because of the way each thread appends, the last record in this page
+      // always has the largest in-epoch ordinal. so, we just need it for read-set
+      if (serializable && epoch > grace_epoch) {
+        uint16_t offset = page->get_record_offset(record_count - 1);
+        xct::LockableXctId* owner_id = page->owner_id_from_offset(offset);
+        CHECK_ERROR_CODE(xct_->add_to_read_set(storage_.get_id(), owner_id->xct_id_, owner_id));
+      }
+
+      *out = SequentialRecordIterator(
+        reinterpret_cast<SequentialRecordBatch*>(page),
+        from_epoch_,
+        to_epoch_);
+      *found = true;
+      SequentialPage* next_page = resolve_volatile(next_pointer);
+      state.volatile_cur_pages_[state.volatile_cur_core_] = next_page;
+      return kErrorCodeOk;
+    }
+
+    DVLOG(0) << "Finished reading all unsafe epochs in node-" << current_node_ << ": " << *this;
+    ++current_node_;
+  }
+
+  ASSERT_ND(*found == false);
+  finished_unsafe_volatiles_ = true;
+
   return kErrorCodeOk;
 }
 
-std::ostream& operator<<(std::ostream& o, const SequentialCursor& /*v*/) {
-  o << "<SequentialCursor>";
-  // TODO(Hideaki) implement
+SequentialPage* SequentialCursor::resolve_volatile(VolatilePagePointer pointer) const {
+  return reinterpret_cast<SequentialPage*>(resolver_.resolve_offset(pointer));
+}
+
+std::ostream& operator<<(std::ostream& o, const SequentialCursor& v) {
+  o << "<SequentialCursor>" << std::endl;
+  o << "  " << v.get_storage() << std::endl;
+  o << "  <from_epoch>" << v.get_from_epoch() << "</from_epoch>" << std::endl;
+  o << "  <to_epoch>" << v.get_to_epoch() << "</to_epoch>" << std::endl;
+  o << "  <order_mode>" << v.order_mode_ << "</order_mode>" << std::endl;
+  o << "  <node_filter>" << v.node_filter_ << "</node_filter>" << std::endl;
+  o << "  <snapshot_only_>" << v.snapshot_only_ << "</snapshot_only_>" << std::endl;
+  o << "  <safe_epoch_only_>" << v.safe_epoch_only_ << "</safe_epoch_only_>" << std::endl;
+  o << "  <buffer_>" << v.buffer_ << "</buffer_>" << std::endl;
+  o << "  <buffer_pages_>" << v.buffer_pages_ << "</buffer_pages_>" << std::endl;
+  o << "  <current_node_>" << v.current_node_ << "</current_node_>" << std::endl;
+  o << "  <finished_snapshots_>" << v.finished_snapshots_ << "</finished_snapshots_>" << std::endl;
+  o << "  <finished_safe_volatiles_>" << v.finished_safe_volatiles_
+    << "</finished_safe_volatiles_>" << std::endl;
+  o << "  <finished_unsafe_volatiles_>" << v.finished_unsafe_volatiles_
+    << "</finished_unsafe_volatiles_>" << std::endl;
   o << "</SequentialCursor>";
   return o;
 }

--- a/foedus-core/src/foedus/thread/thread.cpp
+++ b/foedus-core/src/foedus/thread/thread.cpp
@@ -83,6 +83,12 @@ ErrorCode Thread::read_a_snapshot_page(
   storage::Page* buffer) {
   return pimpl_->read_a_snapshot_page(page_id, buffer);
 }
+ErrorCode Thread::read_snapshot_pages(
+  storage::SnapshotPagePointer page_id_begin,
+  uint32_t page_count,
+  storage::Page* buffer) {
+  return pimpl_->read_snapshot_pages(page_id_begin, page_count, buffer);
+}
 ErrorCode Thread::find_or_read_a_snapshot_page(
   storage::SnapshotPagePointer page_id,
   storage::Page** out) {

--- a/foedus-core/src/foedus/xct/xct_manager_pimpl.cpp
+++ b/foedus-core/src/foedus/xct/xct_manager_pimpl.cpp
@@ -146,7 +146,11 @@ void XctManagerPimpl::handle_epoch_chime() {
         break;
       }
       if (get_requested_global_epoch() <= get_current_global_epoch())  {  // otherwise no sleep
-        bool signaled = control_block_->epoch_chime_wakeup_.timedwait(demand, interval_microsec);
+        bool signaled = control_block_->epoch_chime_wakeup_.timedwait(
+          demand,
+          interval_microsec,
+          soc::kDefaultPollingSpins,
+          interval_microsec);
         VLOG(1) << "epoch_chime_thread. wokeup with " << (signaled ? "signal" : "timeout");
       }
     }

--- a/foedus-core/src/foedus/xct/xct_manager_pimpl.cpp
+++ b/foedus-core/src/foedus/xct/xct_manager_pimpl.cpp
@@ -58,6 +58,13 @@ Epoch       XctManager::get_current_global_epoch() const {
 Epoch       XctManager::get_current_global_epoch_weak() const {
   return pimpl_->get_current_global_epoch_weak();
 }
+Epoch       XctManager::get_current_grace_epoch() const {
+  return pimpl_->get_current_global_epoch().one_less();
+}
+Epoch       XctManager::get_current_grace_epoch_weak() const {
+  return pimpl_->get_current_global_epoch_weak().one_less();
+}
+
 void        XctManager::advance_current_global_epoch() { pimpl_->advance_current_global_epoch(); }
 ErrorCode   XctManager::wait_for_commit(Epoch commit_epoch, int64_t wait_microseconds) {
   return pimpl_->wait_for_commit(commit_epoch, wait_microseconds);

--- a/tests-core/src/foedus/soc/test_shared_polling.cpp
+++ b/tests-core/src/foedus/soc/test_shared_polling.cpp
@@ -15,6 +15,7 @@
  * HP designates this particular file as subject to the "Classpath" exception
  * as provided by HP in the LICENSE.txt file that accompanied this code.
  */
+#include <valgrind.h>
 #include <gtest/gtest.h>
 
 #include <chrono>
@@ -88,7 +89,11 @@ void run_thread_hold_longtime(SharedPolling* polling) {
   // NOTE: Although 1-sec wait seems too long, this is required for valgrind version of tests.
   // On valgrind, context switch is really really infrequent (even if we call yield).
   // Thus, we had a valgrind test-failure with 100ms wait. Fixes #7.
-  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+  uint64_t longtime_ms = 100;
+  if (RUNNING_ON_VALGRIND) {
+    longtime_ms = 1000;
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(longtime_ms));
   polling->signal();
 }
 

--- a/tests-core/src/foedus/storage/sequential/CMakeLists.txt
+++ b/tests-core/src/foedus/storage/sequential/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_foedus_test_individual(test_sequential_basic "Create;CreateAndDrop;CreateAndWrite")
+add_foedus_test_individual(test_sequential_cursor "IteratorRawPage")
 add_foedus_test_individual(test_sequential_volatile_list "Empty;SingleThread;TwoThreads;FourThreads")
 
 set(test_sequential_tpcb_individuals

--- a/tests-core/src/foedus/storage/sequential/CMakeLists.txt
+++ b/tests-core/src/foedus/storage/sequential/CMakeLists.txt
@@ -1,5 +1,16 @@
 add_foedus_test_individual(test_sequential_basic "Create;CreateAndDrop;CreateAndWrite")
-add_foedus_test_individual(test_sequential_cursor "IteratorRawPage")
+
+set(test_sequential_cursor_individuals
+  IteratorRawPage
+  Volatile1Node
+  Snapshot1Node
+  Both1Node
+  Volatile2Node
+  Snapshot2Node
+  Both2Node
+  )
+add_foedus_test_individual(test_sequential_cursor "${test_sequential_cursor_individuals}")
+
 add_foedus_test_individual(test_sequential_volatile_list "Empty;SingleThread;TwoThreads;FourThreads")
 
 set(test_sequential_tpcb_individuals

--- a/tests-core/src/foedus/storage/sequential/test_sequential_cursor.cpp
+++ b/tests-core/src/foedus/storage/sequential/test_sequential_cursor.cpp
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2014-2015, Hewlett-Packard Development Company, LP.
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+ * more details. You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ *
+ * HP designates this particular file as subject to the "Classpath" exception
+ * as provided by HP in the LICENSE.txt file that accompanied this code.
+ */
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+
+#include "foedus/epoch.hpp"
+#include "foedus/test_common.hpp"
+#include "foedus/memory/aligned_memory.hpp"
+#include "foedus/storage/sequential/sequential_cursor.hpp"
+#include "foedus/storage/sequential/sequential_page_impl.hpp"
+#include "foedus/xct/xct_id.hpp"
+
+namespace foedus {
+namespace storage {
+namespace sequential {
+DEFINE_TEST_CASE_PACKAGE(SequentialCursorTest, foedus.storage.sequential);
+
+TEST(SequentialCursorTest, IteratorRawPage) {
+  // construct a page by directly manipulating the page.
+  memory::AlignedMemory memory;
+  memory.alloc(1 << 12, 1 << 12, memory::AlignedMemory::kNumaAllocOnnode, 0);
+  SequentialPage* page = reinterpret_cast<SequentialPage*>(memory.get_block());
+  page->initialize_snapshot_page(1, to_snapshot_page_pointer(1, 0, 1));
+
+  const uint16_t kRecords = 12;
+  const Epoch::EpochInteger kBeginEpoch = 42;
+  uint16_t next_epoch_count = 0;
+  for (uint16_t i = 0; i < kRecords; ++i) {
+    xct::XctId xct_id;
+    Epoch::EpochInteger epoch;
+    if (i % 3 == 0 || i % 2 == 0) {
+      epoch = kBeginEpoch;
+    } else {
+      epoch = kBeginEpoch + 1;
+      ++next_epoch_count;
+    }
+    xct_id.set(epoch, 123);
+    std::stringstream str;
+    str << "data_" << i;
+    std::string payload = str.str();
+    page->append_record_nosync(xct_id, payload.size(), payload.data());
+  }
+
+  // so far SequentialPage and SequentialRecordBatch has the exact same layout
+  const SequentialRecordBatch* batch = reinterpret_cast<const SequentialRecordBatch*>(page);
+
+  // full-scan test
+  {
+    SequentialRecordIterator it(batch, Epoch(1), Epoch(100));
+    for (uint16_t i = 0; i < kRecords; ++i) {
+      EXPECT_TRUE(it.is_valid());
+      if (i % 3 == 0 || i % 2 == 0) {
+        EXPECT_EQ(Epoch(kBeginEpoch), it.get_cur_record_epoch()) << i;
+      } else {
+        EXPECT_EQ(Epoch(kBeginEpoch + 1), it.get_cur_record_epoch()) << i;
+      }
+      std::stringstream str;
+      str << "data_" << i;
+      std::string payload = str.str();
+      uint16_t len = it.get_cur_record_length();
+      EXPECT_EQ(payload.size(), len) << i;
+
+      char buffer[128];
+      it.copy_cur_record(buffer, 128);
+      EXPECT_EQ(payload, std::string(buffer, len)) << i;
+      EXPECT_EQ(payload, std::string(it.get_cur_record_raw(), len)) << i;
+
+      it.next();
+    }
+
+    EXPECT_FALSE(it.is_valid());
+  }
+
+  // read only kBeginEpoch
+  {
+    SequentialRecordIterator it(batch, Epoch(kBeginEpoch), Epoch(kBeginEpoch + 1));
+    for (uint16_t i = 0; i < kRecords; ++i) {
+      if (i % 3 == 0 || i % 2 == 0) {
+        EXPECT_TRUE(it.is_valid());
+        EXPECT_EQ(Epoch(kBeginEpoch), it.get_cur_record_epoch()) << i;
+      } else {
+        continue;
+      }
+
+      std::stringstream str;
+      str << "data_" << i;
+      std::string payload = str.str();
+      uint16_t len = it.get_cur_record_length();
+      EXPECT_EQ(payload.size(), len) << i;
+
+      char buffer[128];
+      it.copy_cur_record(buffer, 128);
+      EXPECT_EQ(payload, std::string(buffer, len)) << i;
+      EXPECT_EQ(payload, std::string(it.get_cur_record_raw(), len)) << i;
+
+      it.next();
+    }
+  }
+
+  // read only kBeginEpoch+1
+  {
+    SequentialRecordIterator it(batch, Epoch(kBeginEpoch + 1), Epoch(kBeginEpoch + 5));
+    for (uint16_t i = 0; i < kRecords; ++i) {
+      if (i % 3 == 0 || i % 2 == 0) {
+        continue;
+      } else {
+        EXPECT_TRUE(it.is_valid());
+        EXPECT_EQ(Epoch(kBeginEpoch + 1), it.get_cur_record_epoch()) << i;
+      }
+
+      std::stringstream str;
+      str << "data_" << i;
+      std::string payload = str.str();
+      uint16_t len = it.get_cur_record_length();
+      EXPECT_EQ(payload.size(), len) << i;
+
+      char buffer[128];
+      it.copy_cur_record(buffer, 128);
+      EXPECT_EQ(payload, std::string(buffer, len)) << i;
+      EXPECT_EQ(payload, std::string(it.get_cur_record_raw(), len)) << i;
+
+      it.next();
+    }
+
+    EXPECT_FALSE(it.is_valid());
+  }
+
+  // read none
+  {
+    SequentialRecordIterator it(batch, Epoch(kBeginEpoch + 10), Epoch(kBeginEpoch + 15));
+    EXPECT_FALSE(it.is_valid());
+    it.next();
+    EXPECT_FALSE(it.is_valid());
+  }
+}
+
+}  // namespace sequential
+}  // namespace storage
+}  // namespace foedus
+
+TEST_MAIN_CAPTURE_SIGNALS(SequentialCursorTest, foedus.storage.sequential);

--- a/tests-core/src/foedus/storage/sequential/test_sequential_cursor.cpp
+++ b/tests-core/src/foedus/storage/sequential/test_sequential_cursor.cpp
@@ -15,17 +15,32 @@
  * HP designates this particular file as subject to the "Classpath" exception
  * as provided by HP in the LICENSE.txt file that accompanied this code.
  */
+#include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <sstream>
 #include <string>
+#include <vector>
 
+#include "foedus/engine.hpp"
 #include "foedus/epoch.hpp"
 #include "foedus/test_common.hpp"
+#include "foedus/log/log_manager.hpp"
 #include "foedus/memory/aligned_memory.hpp"
+#include "foedus/memory/engine_memory.hpp"
+#include "foedus/proc/proc_manager.hpp"
+#include "foedus/snapshot/snapshot_manager.hpp"
+#include "foedus/storage/storage_manager.hpp"
 #include "foedus/storage/sequential/sequential_cursor.hpp"
+#include "foedus/storage/sequential/sequential_metadata.hpp"
 #include "foedus/storage/sequential/sequential_page_impl.hpp"
+#include "foedus/thread/impersonate_session.hpp"
+#include "foedus/thread/thread.hpp"
+#include "foedus/thread/thread_pool.hpp"
+#include "foedus/xct/xct.hpp"
 #include "foedus/xct/xct_id.hpp"
+#include "foedus/xct/xct_manager.hpp"
 
 namespace foedus {
 namespace storage {
@@ -150,6 +165,498 @@ TEST(SequentialCursorTest, IteratorRawPage) {
     EXPECT_FALSE(it.is_valid());
   }
 }
+
+const uint32_t kRecordsPerXct = 1 << 6;
+const uint32_t kXctsPerCore = 1 << 6;
+const uint32_t kMaxXctsPerEpoch = 1 << 3;
+const uint64_t kRecordsPerCore = kRecordsPerXct * kXctsPerCore;
+const uint16_t kCoresPerNode = 1U;
+const uint64_t kRecordsPerNode = kRecordsPerCore * kCoresPerNode;
+const char*    kStorageName = "test";
+
+/**
+ * For the verification, each thread share their status in this struct.
+ */
+struct PerThreadData {
+  /** The commit-epoch of each transaction */
+  Epoch xct_epochs_[kXctsPerCore];
+  uint32_t aborts_in_cursor_;
+};
+
+struct SharedData {
+  PerThreadData* get_per_thread_data(uint16_t node, uint16_t core_ordinal) {
+    ASSERT_ND(node < node_count_);
+    ASSERT_ND(core_ordinal < kCoresPerNode);
+    uint16_t index = node * kCoresPerNode + core_ordinal;
+    return per_thread_data_ + index;
+  }
+
+  uint64_t calculate_correct_record_count(
+    Epoch from_epoch,
+    Epoch to_epoch,
+    int32_t node_filter) const {
+    uint64_t result = 0;
+    for (uint16_t node = 0; node < node_count_; ++node) {
+      if (node_filter >= 0 && node != node_filter) {
+        continue;
+      }
+      for (uint16_t core = 0; core < kCoresPerNode; ++core) {
+        for (uint32_t x = 0; x < kXctsPerCore; ++x) {
+          Epoch epoch = per_thread_data_[node * kCoresPerNode + core].xct_epochs_[x];
+          if (epoch >= from_epoch && epoch < to_epoch) {
+            ++result;
+          }
+        }
+      }
+    }
+    ASSERT_ND(result * kRecordsPerXct <= total_records_);
+    return result * kRecordsPerXct;
+  }
+
+  PerThreadData per_thread_data_[4];  // at most 2-nodes * 2-cores
+  uint64_t total_records_;
+  uint16_t node_count_;
+  bool has_volatile_;
+  bool has_snapshot_;
+  Epoch snapshot_epoch_;
+  Epoch begin_epoch_;
+  Epoch end_epoch_;
+
+  /**
+   * Used in the loader.
+   * the thread that made it == node_count*kCoresPerNode should wake up the epoch chime
+   */
+  std::atomic<uint32_t> epoch_waiting_count_;
+};
+
+ErrorStack load_task(const proc::ProcArguments& args) {
+  thread::Thread* context = args.context_;
+  SequentialStorage sequential(context->get_engine(), kStorageName);
+  EXPECT_TRUE(sequential.exists());
+
+  SharedData* shared_data = reinterpret_cast<SharedData*>(
+    context->get_engine()->get_memory_manager()->get_shared_user_memory());
+  uint16_t node = thread::decompose_numa_node(context->get_thread_id());
+  uint16_t core_ordinal = thread::decompose_numa_local_ordinal(context->get_thread_id());
+  PerThreadData* my_data = shared_data->get_per_thread_data(node, core_ordinal);
+
+  xct::XctManager* xct_manager = context->get_engine()->get_xct_manager();
+  const Epoch first_epoch = xct_manager->get_current_global_epoch();
+
+  Epoch cur_epoch = first_epoch;
+  uint32_t cur_epoch_xcts = 0;
+  LOG(INFO) << "Thread-" << context->get_thread_id() << " stated loading data. cur_epoch="
+    << cur_epoch;
+
+  memory::AlignedMemory read_buffer(
+    1U << 16,
+    1U << 12,
+    memory::AlignedMemory::kNumaAllocOnnode,
+    context->get_numa_node());
+
+  const uint64_t offset = node * kRecordsPerNode + core_ordinal * kRecordsPerCore;
+  uint64_t data;
+  Epoch last_epoch;
+  for (uint32_t x = 0; x < kXctsPerCore; ++x) {
+    // LOG(INFO) << "xct=" << x
+    //  << context->get_engine()->get_memory_manager()->dump_free_memory_stat();
+
+    WRAP_ERROR_CODE(xct_manager->begin_xct(context, xct::kSerializable));
+    for (uint32_t t = 0; t < kRecordsPerXct; ++t) {
+      data = offset + x * kRecordsPerXct + t;
+      ASSERT_ND(data < shared_data->total_records_);
+      WRAP_ERROR_CODE(sequential.append_record(context, &data, sizeof(data)));
+    }
+    Epoch commit_epoch;
+    WRAP_ERROR_CODE(xct_manager->precommit_xct(context, &commit_epoch));
+    my_data->xct_epochs_[x] = commit_epoch;
+    ASSERT_ND(commit_epoch >= cur_epoch);
+    last_epoch = commit_epoch;
+
+    // just as a random test, run a cursor now in a racy setting
+    // this might or might not abort because of page-set/read-set.
+    WRAP_ERROR_CODE(xct_manager->begin_xct(context, xct::kSerializable));
+    SequentialCursor cursor(
+      context,
+      sequential,
+      read_buffer.get_block(),
+      read_buffer.get_size(),
+      SequentialCursor::kNodeFirstMode,
+      first_epoch,
+      last_epoch.one_more().one_more());  // so that we touch even unsafe epochs
+    SequentialRecordIterator it;
+    while (cursor.is_valid()) {
+      WRAP_ERROR_CODE(cursor.next_batch(&it));
+      while (it.is_valid()) {
+        Epoch record_epoch = it.get_cur_record_epoch();
+        EXPECT_TRUE(record_epoch.is_valid());
+        it.next();
+      }
+    }
+    ErrorCode code = xct_manager->precommit_xct(context, &commit_epoch);
+    EXPECT_TRUE(code == kErrorCodeOk || code == kErrorCodeXctRaceAbort);
+    ASSERT_ND(!context->get_current_xct().is_active());
+    if (code == kErrorCodeXctRaceAbort) {
+      // this will probably happen a few times during the test, but might not happen.
+      LOG(INFO) << "Thread-" << context->get_thread_id() << " observed aborts in a"
+        << " racy cursor execution. This is expected.";
+      ++my_data->aborts_in_cursor_;
+    }
+
+    // Make sure we output records in several epochs. So, wait a bit.
+    if (commit_epoch > cur_epoch) {
+      cur_epoch = commit_epoch;
+      cur_epoch_xcts = 1;
+    } else {
+      ++cur_epoch_xcts;
+      if (cur_epoch_xcts >= kMaxXctsPerEpoch) {
+        LOG(INFO) << "Thread-" << context->get_thread_id() << " finished " << x << " xcts."
+          << " Now waiting for next epoch.. cur_epoch=" << cur_epoch;
+        Epoch next_epoch = cur_epoch.one_more();
+        uint32_t new_count = shared_data->epoch_waiting_count_.fetch_add(1U) + 1U;
+        if (new_count == shared_data->node_count_ * kCoresPerNode) {
+          LOG(INFO) << "Okay okay, i'll wake up the epoch chime";
+          xct_manager->advance_current_global_epoch();
+        } else {
+          xct_manager->wait_for_current_global_epoch(next_epoch);
+        }
+        --shared_data->epoch_waiting_count_;
+      }
+    }
+  }
+
+  WRAP_ERROR_CODE(xct_manager->wait_for_commit(last_epoch));
+  LOG(INFO) << "Thread-" << context->get_thread_id() << " loaded data. cur_epoch=" << cur_epoch;
+  return foedus::kRetOk;
+}
+
+ErrorStack scan_task_impl(
+  const proc::ProcArguments& args,
+  Epoch from_epoch,
+  Epoch to_epoch,
+  int32_t node_filter) {
+  thread::Thread* context = args.context_;
+  SequentialStorage sequential(context->get_engine(), kStorageName);
+  EXPECT_TRUE(sequential.exists());
+
+  SharedData* shared_data = reinterpret_cast<SharedData*>(
+    context->get_engine()->get_memory_manager()->get_shared_user_memory());
+  SCOPED_TRACE(testing::Message()
+    << shared_data->node_count_ << " nodes"
+    << (shared_data->has_snapshot_ ? " has_snapshot" : "")
+    << (shared_data->has_volatile_ ? " has_volatile" : "")
+    << " from=" << from_epoch << ", to=" << to_epoch << ", node_filter=" << node_filter);
+
+  xct::XctManager* xct_manager = context->get_engine()->get_xct_manager();
+
+  memory::AlignedMemory read_buffer(
+    1U << 13,  // deliberately using a small buffer to test page-flip
+    1U << 12,
+    memory::AlignedMemory::kNumaAllocOnnode,
+    context->get_numa_node());
+
+  uint16_t node_count = shared_data->node_count_;
+
+  uint64_t record_count = 0;
+  WRAP_ERROR_CODE(xct_manager->begin_xct(context, xct::kSerializable));
+  SequentialCursor cursor(
+    context,
+    sequential,
+    read_buffer.get_block(),
+    read_buffer.get_size(),
+    SequentialCursor::kNodeFirstMode,
+    from_epoch,
+    to_epoch,
+    node_filter);
+  std::vector<bool> observed;
+  observed.assign(shared_data->total_records_, false);
+  ASSERT_ND(observed.size() == shared_data->total_records_);
+  while (cursor.is_valid()) {
+    SequentialRecordIterator it;
+    if (from_epoch.value() == 11U && record_count > 420) {
+      LOG(INFO) << "aa";
+    }
+    WRAP_ERROR_CODE(cursor.next_batch(&it));
+
+    const SequentialPage* page = reinterpret_cast<const SequentialPage*>(it.get_raw_batch());
+    uint16_t node = 0;
+    Epoch single_epoch;
+    if (it.is_valid()) {
+      if (page->header().snapshot_) {
+        ASSERT_ND(shared_data->has_snapshot_);
+        node = extract_numa_node_from_snapshot_pointer(page->header().page_id_);
+      } else {
+        ASSERT_ND(shared_data->has_volatile_);
+        VolatilePagePointer page_id;
+        page_id.word = page->header().page_id_;
+        node = page_id.components.numa_node;
+        EXPECT_GT(page_id.components.offset, 0);
+
+        // volatile sequential page is guaranteed to contain only one epoch
+        single_epoch = page->get_first_record_epoch();
+        EXPECT_TRUE(single_epoch.is_valid());
+        EXPECT_GE(single_epoch, from_epoch);
+        EXPECT_LT(single_epoch, to_epoch);
+      }
+      page->assert_consistent();
+    }
+    EXPECT_LT(node, node_count);
+
+    while (it.is_valid()) {
+      Epoch record_epoch = it.get_cur_record_epoch();
+      if (single_epoch.is_valid()) {
+        EXPECT_EQ(single_epoch, record_epoch);
+      }
+      EXPECT_FALSE(it.get_cur_record_owner_id()->lock_.is_keylocked());
+      EXPECT_FALSE(it.get_cur_record_owner_id()->lock_.is_rangelocked());
+      const char* payload = it.get_cur_record_raw();
+      uint64_t data = *reinterpret_cast<const uint64_t*>(payload);
+      ASSERT_ND(data < observed.size());
+      uint64_t record_node = data / kRecordsPerNode;
+      EXPECT_EQ(node, record_node) << data;
+      uint64_t core_ordinal = (data % kRecordsPerNode) / kRecordsPerCore;
+      EXPECT_LT(core_ordinal, kCoresPerNode) << data;
+      if (node_filter >= 0) {
+        EXPECT_EQ(node_filter, record_node) << data;
+      }
+      EXPECT_TRUE(record_epoch.is_valid()) << data;
+      EXPECT_GE(record_epoch, from_epoch) << data;
+      EXPECT_LT(record_epoch, to_epoch) << data;
+
+      uint64_t per_core_index = data % kRecordsPerCore;
+      uint64_t xct = per_core_index / kRecordsPerXct;
+      PerThreadData* per_thread_data = shared_data->get_per_thread_data(record_node, core_ordinal);
+      Epoch correct_epoch = per_thread_data->xct_epochs_[xct];
+      EXPECT_EQ(correct_epoch, record_epoch) << data;
+
+      EXPECT_FALSE(observed[data]) << data;
+      observed[data] = true;
+      ++record_count;
+      it.next();
+    }
+  }
+
+  uint64_t correct_count
+    = shared_data->calculate_correct_record_count(from_epoch, to_epoch, node_filter);
+  if (from_epoch == shared_data->begin_epoch_
+    && to_epoch == shared_data->end_epoch_
+    && (node_filter == -1 || node_count == 1U)) {
+    // full scan case
+    EXPECT_EQ(node_count * kCoresPerNode * kXctsPerCore * kRecordsPerXct, correct_count);
+  }
+  EXPECT_EQ(correct_count, record_count);
+
+  // Above tests can detect records that shouldn't be returned.
+  // Now look for records that should have been returned.
+  // Total count alone isn't enough informative.
+  for (uint32_t node = 0; node < shared_data->node_count_; ++node) {
+    if (node_filter >= 0 && node != static_cast<uint32_t>(node_filter)) {
+      continue;
+    }
+    for (uint32_t core = 0; core < kCoresPerNode; ++core) {
+      PerThreadData* per_thread_data = shared_data->get_per_thread_data(node, core);
+      for (uint32_t x = 0; x < kXctsPerCore; ++x) {
+        Epoch epoch = per_thread_data->xct_epochs_[x];
+        if (epoch < from_epoch || epoch >= to_epoch) {
+          continue;
+        }
+        uint64_t offset = node * kRecordsPerNode + core * kRecordsPerCore + x * kRecordsPerXct;
+        for (uint32_t record = offset; record < offset + kRecordsPerXct; ++record) {
+          EXPECT_TRUE(observed[record]) << "record=" << record
+            << "(node=" << node << ", core=" << core << ", xct=" << x << ")";
+        }
+      }
+    }
+  }
+
+
+  Epoch commit_epoch;
+  WRAP_ERROR_CODE(xct_manager->precommit_xct(context, &commit_epoch));
+
+  return foedus::kRetOk;
+}
+
+ErrorStack scan_task(const proc::ProcArguments& args) {
+  thread::Thread* context = args.context_;
+
+  SharedData* shared_data = reinterpret_cast<SharedData*>(
+    context->get_engine()->get_memory_manager()->get_shared_user_memory());
+  LOG(INFO) << "Stated scanning";
+
+  // First, test full-scan without unsafe epochs
+  // Because we made everything durable, this actually returns all records
+  CHECK_ERROR(scan_task_impl(args, shared_data->begin_epoch_, shared_data->end_epoch_, -1));
+
+  LOG(INFO) << "full scan test done";
+
+  // Second, test partial-scan with epochs, including unsafe epochs.
+  const uint32_t kEpochStep = 2;
+  Epoch initial_from = shared_data->begin_epoch_.one_less();  // -1 to test empty-epoch case.
+  for (Epoch::EpochInteger from = initial_from.value();
+        from < shared_data->end_epoch_.value();
+        from += kEpochStep) {
+    Epoch from_epoch(from);
+    Epoch to_epoch(from + kEpochStep);
+    CHECK_ERROR(scan_task_impl(args, from_epoch, to_epoch, -1));
+  }
+
+  LOG(INFO) << "partial scan test done";
+
+  // Finally, partial-scan with node filter.
+  for (Epoch::EpochInteger from = initial_from.value();
+        from < shared_data->end_epoch_.value();
+        from += kEpochStep) {
+    Epoch from_epoch(from);
+    Epoch to_epoch(from + kEpochStep);
+    for (uint16_t node = 0; node < shared_data->node_count_; ++node) {
+      CHECK_ERROR(scan_task_impl(args, from_epoch, to_epoch, node));
+    }
+  }
+
+  LOG(INFO) << "all tests done";
+  return foedus::kRetOk;
+}
+
+void test_cursor(
+  bool has_volatile,
+  bool has_snapshot,
+  bool multi_node) {
+  EngineOptions options = get_tiny_options();
+  const uint16_t kRecordsPerPageConservative = 8;
+  uint32_t pages_conservative
+    = kRecordsPerXct * kXctsPerCore / kRecordsPerPageConservative;
+  options.memory_.page_pool_size_mb_per_node_
+    = kCoresPerNode * assorted::int_div_ceil(pages_conservative * kPageSize, 1ULL << 20);
+  options.thread_.thread_count_per_group_ = kCoresPerNode;
+  uint16_t node_count = 1;
+  if (multi_node) {
+    node_count = 2;
+  }
+  options.thread_.group_count_ = node_count;
+
+  Engine engine(options);
+  engine.get_proc_manager()->pre_register(proc::ProcAndName("load_task", load_task));
+  engine.get_proc_manager()->pre_register(proc::ProcAndName("scan_task", scan_task));
+  COERCE_ERROR(engine.initialize());
+  {
+    UninitializeGuard guard(&engine);
+    {
+      SequentialMetadata meta(kStorageName);
+      SequentialStorage storage;
+      Epoch epoch;
+      COERCE_ERROR(engine.get_storage_manager()->create_sequential(&meta, &storage, &epoch));
+      EXPECT_TRUE(storage.exists());
+
+      SharedData* shared_data = reinterpret_cast<SharedData*>(
+        engine.get_memory_manager()->get_shared_user_memory());
+      ASSERT_ND(engine.get_memory_manager()->get_shared_user_memory_size() >= sizeof(SharedData));
+      std::memset(shared_data, 0, sizeof(SharedData));
+      shared_data->total_records_ = node_count * kRecordsPerNode;
+      shared_data->node_count_ = node_count;
+      shared_data->has_volatile_ = has_volatile;
+      shared_data->has_snapshot_ = has_snapshot;
+
+      xct::XctManager* xct_manager = engine.get_xct_manager();
+      const Epoch begin_epoch = xct_manager->get_current_global_epoch();
+      shared_data->begin_epoch_ = begin_epoch;
+
+      // First, load the data in each core.
+      std::vector< thread::ImpersonateSession > sessions;
+      for (uint16_t node = 0; node < node_count; ++node) {
+        for (uint16_t core = 0; core < kCoresPerNode; ++core) {
+          thread::ThreadId thread_id = thread::compose_thread_id(node, core);
+          thread::ImpersonateSession session;
+          bool impersonated = engine.get_thread_pool()->impersonate_on_numa_core(
+            thread_id,
+            "load_task",
+            nullptr,
+            0,
+            &session);
+          EXPECT_TRUE(impersonated);
+          sessions.emplace_back(std::move(session));
+        }
+      }
+
+      LOG(INFO) << "Launched loaders. waitnig...";
+      for (thread::ImpersonateSession& s : sessions) {
+        COERCE_ERROR(s.get_result());
+        s.release();
+      }
+      LOG(INFO) << "Loaders all done.";
+
+      engine.get_xct_manager()->advance_current_global_epoch();
+
+      const Epoch end_epoch = xct_manager->get_current_global_epoch();
+      shared_data->end_epoch_ = end_epoch;
+
+      uint64_t all_records = shared_data->calculate_correct_record_count(
+        shared_data->begin_epoch_,
+        shared_data->end_epoch_,
+        -1);
+      EXPECT_EQ(shared_data->total_records_, all_records);
+      for (uint16_t node = 0; node < node_count; ++node) {
+        uint64_t node_records = shared_data->calculate_correct_record_count(
+          shared_data->begin_epoch_,
+          shared_data->end_epoch_,
+          node);
+        EXPECT_EQ(shared_data->total_records_ / node_count, node_records);
+      }
+
+      // Let's do sanity check on committed epochs. Also, we need to pick
+      // epochs up to which we take snapshot.
+      for (uint16_t node = 0; node < node_count; ++node) {
+        for (uint16_t core = 0; core < kCoresPerNode; ++core) {
+          uint32_t ordinal = node * kCoresPerNode + core;
+          const PerThreadData& data = shared_data->per_thread_data_[ordinal];
+          for (uint32_t x = 0; x < kXctsPerCore; ++x) {
+            Epoch epoch = data.xct_epochs_[x];
+            EXPECT_TRUE(epoch.is_valid());
+            EXPECT_GE(epoch, begin_epoch);
+            EXPECT_LT(epoch, end_epoch);
+          }
+        }
+      }
+      Epoch middle_epoch = shared_data->per_thread_data_[0].xct_epochs_[kXctsPerCore / 2];
+      LOG(INFO) << "middle_epoch=" << middle_epoch << ", begin_epoch=" << begin_epoch
+        << ", end_epoch=" << end_epoch << ", Thread-0's first_epoch="
+        << shared_data->per_thread_data_[0].xct_epochs_[0]
+        << ", Thread-0's last_epoch="
+        << shared_data->per_thread_data_[0].xct_epochs_[kXctsPerCore - 1]
+        << ", Thread-0's aborts during racy cursors="
+        << shared_data->per_thread_data_[0].aborts_in_cursor_ << "/" << kXctsPerCore;
+
+      // let's take snapshot
+      if (has_snapshot) {
+        Epoch snapshot_epoch;
+        ASSERT_ND(has_volatile || has_snapshot);
+        if (!has_volatile) {
+          // snapshot everything that is durable
+          snapshot_epoch = engine.get_log_manager()->get_durable_global_epoch();
+        } else {
+          // snapshot only half of them
+          snapshot_epoch = middle_epoch;
+        }
+
+        engine.get_snapshot_manager()->trigger_snapshot_immediate(true, snapshot_epoch);
+        EXPECT_EQ(engine.get_snapshot_manager()->get_snapshot_epoch(), snapshot_epoch);
+        shared_data->snapshot_epoch_ = snapshot_epoch;
+      }
+
+      // Finally, scan the outcomes!
+      COERCE_ERROR(engine.get_thread_pool()->impersonate_synchronous("scan_task"));
+    }
+    COERCE_ERROR(engine.uninitialize());
+  }
+  cleanup_test(options);
+}
+
+TEST(SequentialCursorTest, Volatile1Node) { test_cursor(true, false, false); }
+TEST(SequentialCursorTest, Snapshot1Node) { test_cursor(false, true, false); }
+TEST(SequentialCursorTest, Both1Node)     { test_cursor(true, true, false); }
+
+TEST(SequentialCursorTest, Volatile2Node) { test_cursor(true, false, true); }
+TEST(SequentialCursorTest, Snapshot2Node) { test_cursor(false, true, true); }
+TEST(SequentialCursorTest, Both2Node)     { test_cursor(true, true, true); }
 
 }  // namespace sequential
 }  // namespace storage


### PR DESCRIPTION
API, Implementation, and Testcases for one of the critical missing feature; scan for sequential storage. Before this merge, there was only an internal hacky methods to read appended records in sequential storage.

Although this merge passes testcases, there is one TODO.
It has only OCC option for serializable xcts reading tail of each volatile linked-list.
This could cause lots of aborts. We should consider locking option too.
So far this is enough. Left a TASK comment. later. in beta.