### PR TITLE
Bug fix: turns out that it was a bug introduced lately. sorry valgrin…

### DIFF
--- a/foedus-core/include/foedus/soc/shared_polling.hpp
+++ b/foedus-core/include/foedus/soc/shared_polling.hpp
@@ -26,7 +26,7 @@ namespace foedus {
 namespace soc {
 
 /** Default value of polling_spins */
-const uint64_t kDefaultPollingSpins = (1ULL << 16);
+const uint64_t kDefaultPollingSpins = (1ULL << 10);
 /** Default value of max_interval_us */
 const uint64_t kDefaultPollingMaxIntervalUs = (1ULL << 15);
 /** Initial value of sleep interval in us */

--- a/foedus-core/src/foedus/soc/shared_polling.cpp
+++ b/foedus-core/src/foedus/soc/shared_polling.cpp
@@ -89,13 +89,10 @@ void SharedPolling::spin_poll(uint64_t demanded_ticket, uint64_t polling_spins) 
     if (cur_ticket_ >= demanded_ticket) {
       return;
     }
-    assorted::spinlock_yield();
-    // keeps calling yield puts too much pressure on CPU,
-    // especially confuses valgrind. let's sleep occasionally.
-    if (i % 8U == 0) {
-      std::this_thread::sleep_for(std::chrono::microseconds(50));
+    if (i % 256 == 0) {
+      assorted::spinlock_yield();
+      assorted::memory_fence_acquire();
     }
-    assorted::memory_fence_acquire();
   }
 }
 

--- a/tests-core/src/foedus/soc/test_shared_polling.cpp
+++ b/tests-core/src/foedus/soc/test_shared_polling.cpp
@@ -87,11 +87,11 @@ TEST(SharedPollingTest, FourThreads) { test_multi(4); }
 
 void run_thread_hold_longtime(SharedPolling* polling) {
   // NOTE: Although 1-sec wait seems too long, this is required for valgrind version of tests.
-  // On valgrind, context switch is really really infrequent (even if we call yield).
+  // On valgrind, the initial spin part might take long time.
   // Thus, we had a valgrind test-failure with 100ms wait. Fixes #7.
-  uint64_t longtime_ms = 1000;
+  uint64_t longtime_ms = 100;
   if (RUNNING_ON_VALGRIND) {
-    longtime_ms = 3000;  // ggrrr, what are you doing, valgrind!
+    longtime_ms = 1000;  //
   }
   std::this_thread::sleep_for(std::chrono::milliseconds(longtime_ms));
   polling->signal();


### PR DESCRIPTION
…d, it wasn't your fault. The issue was 64k spins with yield/barrier everytime takes really long time, even longer than the timeout.