### PR TITLE
Gigantic merge new_mpage: new master-tree page layout

### DIFF
--- a/experiments-core/include/foedus/tpcc/tpcc_load.hpp
+++ b/experiments-core/include/foedus/tpcc/tpcc_load.hpp
@@ -28,6 +28,7 @@
 #include "foedus/memory/aligned_memory.hpp"
 #include "foedus/proc/proc_id.hpp"
 #include "foedus/storage/fwd.hpp"
+#include "foedus/storage/masstree/masstree_id.hpp"
 #include "foedus/thread/fwd.hpp"
 #include "foedus/tpcc/tpcc_scale.hpp"
 #include "foedus/tpcc/tpcc_schema.hpp"
@@ -50,7 +51,8 @@ ErrorStack create_masstree(
   Engine* engine,
   const storage::StorageName& name,
   bool keep_all_volatile_pages,
-  float border_fill_factor);
+  float border_fill_factor,
+  storage::masstree::Layer min_layer_hint);
 ErrorStack create_sequential(Engine* engine, const storage::StorageName& name);
 
 class TpccFinishupTask {

--- a/experiments-core/src/foedus/tpcc/tpcc_load.cpp
+++ b/experiments-core/src/foedus/tpcc/tpcc_load.cpp
@@ -77,6 +77,16 @@ ErrorStack tpcc_load_task(const proc::ProcArguments& args) {
   return task.run(context);
 }
 
+storage::masstree::SlotIndex estimate_masstree_records(
+  uint8_t layer,
+  storage::masstree::KeyLength key_length,
+  storage::masstree::PayloadLength payload_length) {
+  return storage::masstree::MasstreeStorage::estimate_records_per_page(
+    layer,
+    key_length,
+    payload_length);
+}
+
 ErrorStack create_all(Engine* engine, Wid total_warehouses) {
   debugging::StopWatch watch;
 
@@ -134,22 +144,22 @@ ErrorStack create_all(Engine* engine, Wid total_warehouses) {
     engine,
     "neworders",
     true,
-    64 * 0.75));
+    estimate_masstree_records(0, sizeof(Wdoid), 0) * 0.75));
   CHECK_ERROR(create_masstree(
     engine,
     "orders",
     true,
-    (storage::masstree::kBorderPageDataPartSize / sizeof(OrderData)) * 0.75));
+    estimate_masstree_records(0, sizeof(Wdcoid), sizeof(OrderData)) * 0.75));
   CHECK_ERROR(create_masstree(
     engine,
     "orders_secondary",
     true,
-    64 * 0.75));
+    estimate_masstree_records(0, sizeof(Wdcoid), 0) * 0.75));
   CHECK_ERROR(create_masstree(
     engine,
     "orderlines",
     true,
-    (storage::masstree::kBorderPageDataPartSize / sizeof(OrderlineData)) * 0.75));
+    estimate_masstree_records(0, sizeof(Wdol), sizeof(OrderlineData)) * 0.75));
 
   CHECK_ERROR(create_array(
     engine,

--- a/experiments-core/src/foedus/tpcc/tpcc_load.cpp
+++ b/experiments-core/src/foedus/tpcc/tpcc_load.cpp
@@ -139,7 +139,7 @@ ErrorStack create_all(Engine* engine, Wid total_warehouses) {
     engine,
     "orders",
     true,
-    (storage::masstree::MasstreeBorderPage::kDataSize / sizeof(OrderData)) * 0.75));
+    (storage::masstree::kBorderPageDataPartSize / sizeof(OrderData)) * 0.75));
   CHECK_ERROR(create_masstree(
     engine,
     "orders_secondary",
@@ -149,7 +149,7 @@ ErrorStack create_all(Engine* engine, Wid total_warehouses) {
     engine,
     "orderlines",
     true,
-    (storage::masstree::MasstreeBorderPage::kDataSize / sizeof(OrderlineData)) * 0.75));
+    (storage::masstree::kBorderPageDataPartSize / sizeof(OrderlineData)) * 0.75));
 
   CHECK_ERROR(create_array(
     engine,

--- a/experiments-core/src/foedus/tpcc/tpcc_load.cpp
+++ b/experiments-core/src/foedus/tpcc/tpcc_load.cpp
@@ -115,7 +115,8 @@ ErrorStack create_all(Engine* engine, Wid total_warehouses) {
     engine,
     "customers_secondary",
     false,
-    0));  // customer is a static table, so why not 100% fill-factor
+    0,  // customer is a static table, so why not 100% fill-factor
+    1U));  // First 8-byte has a very small cardinality, so most records will be in layer-1.
 
   CHECK_ERROR(create_array(
     engine,
@@ -144,22 +145,26 @@ ErrorStack create_all(Engine* engine, Wid total_warehouses) {
     engine,
     "neworders",
     true,
-    estimate_masstree_records(0, sizeof(Wdoid), 0) * 0.75));
+    estimate_masstree_records(0, sizeof(Wdoid), 0) * 0.75,
+    0));
   CHECK_ERROR(create_masstree(
     engine,
     "orders",
     true,
-    estimate_masstree_records(0, sizeof(Wdcoid), sizeof(OrderData)) * 0.75));
+    estimate_masstree_records(0, sizeof(Wdcoid), sizeof(OrderData)) * 0.75,
+    0));
   CHECK_ERROR(create_masstree(
     engine,
     "orders_secondary",
     true,
-    estimate_masstree_records(0, sizeof(Wdcoid), 0) * 0.75));
+    estimate_masstree_records(0, sizeof(Wdcoid), 0) * 0.75,
+    0));
   CHECK_ERROR(create_masstree(
     engine,
     "orderlines",
     true,
-    estimate_masstree_records(0, sizeof(Wdol), sizeof(OrderlineData)) * 0.75));
+    estimate_masstree_records(0, sizeof(Wdol), sizeof(OrderlineData)) * 0.75,
+    0));
 
   CHECK_ERROR(create_array(
     engine,
@@ -227,9 +232,11 @@ ErrorStack create_masstree(
   Engine* engine,
   const storage::StorageName& name,
   bool keep_all_volatile_pages,
-  float border_fill_factor) {
+  float border_fill_factor,
+  storage::masstree::Layer min_layer_hint) {
   Epoch ep;
   storage::masstree::MasstreeMetadata meta(name, border_fill_factor);
+  meta.min_layer_hint_ = min_layer_hint;
   if (keep_all_volatile_pages) {
     meta.snapshot_thresholds_.snapshot_keep_threshold_ = 0xFFFFFFFFU;
     meta.snapshot_drop_volatile_pages_btree_levels_ = 0;

--- a/foedus-core/include/foedus/storage/fwd.hpp
+++ b/foedus-core/include/foedus/storage/fwd.hpp
@@ -31,6 +31,7 @@ struct  DualPagePointer;
 struct  Metadata;
 struct  Page;
 struct  PageVersion;
+struct  PageVersionLockScope;
 class   Partitioner;
 struct  PartitionerMetadata;
 struct  Record;

--- a/foedus-core/include/foedus/storage/masstree/masstree_cursor.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_cursor.hpp
@@ -212,19 +212,19 @@ class MasstreeCursor CXX11_FINAL {
   bool        reached_end_;
 
   /** If this value is zero, it means supremum. */
-  uint16_t    end_key_length_;
+  KeyLength   end_key_length_;
   /** If this value is zero, it means supremum. */
-  uint16_t    cur_key_length_;
-  uint16_t    cur_payload_length_;
+  KeyLength   cur_key_length_;
+  PayloadLength cur_payload_length_;
   /** If this value is zero, it means supremum. */
-  uint16_t    search_key_length_;
+  KeyLength   search_key_length_;
   SearchType  search_type_;
-  uint8_t     search_key_in_layer_extremum_;
+  bool        search_key_in_layer_extremum_;
 
   /** number of higher layer pages. the current border page is not included. so, might be 0. */
   uint16_t    route_count_;
 
-  uint8_t     cur_key_in_layer_remaining_;
+  KeyLength   cur_key_in_layer_remaining_;
   KeySlice    cur_key_in_layer_slice_;
   xct::XctId  cur_key_observed_owner_id_;
   xct::LockableXctId* cur_key_owner_id_address;
@@ -256,7 +256,7 @@ class MasstreeCursor CXX11_FINAL {
     KeySlice slice,
     uint8_t layer,
     const char* full_key,
-    uint16_t full_length) const;
+    KeyLength full_length) const;
 
   uint8_t       get_cur_index() const ALWAYS_INLINE {
     ASSERT_ND(is_valid_record());
@@ -319,24 +319,10 @@ class MasstreeCursor CXX11_FINAL {
   }
   void assert_route() const ALWAYS_INLINE {
 #ifndef NDEBUG
-    for (uint16_t i = 0; i + 1U < route_count_; ++i) {
-      const Route* route = routes_ + i;
-      ASSERT_ND(route->page_);
-      if (route->stable_.is_moved()) {
-        // then we don't use any information in this path
-      } else if (reinterpret_cast<Page*>(route->page_)->get_header().get_page_type()
-        == kMasstreeBorderPageType) {
-        ASSERT_ND(route->index_ < kMaxRecords);
-        ASSERT_ND(route->index_ < route->key_count_);
-      } else {
-        ASSERT_ND(route->index_ <= route->key_count_);
-        ASSERT_ND(route->index_ <= kMaxIntermediateSeparators);
-        ASSERT_ND(route->index_mini_ <= route->key_count_mini_);
-        ASSERT_ND(route->index_mini_ <= kMaxIntermediateMiniSeparators);
-      }
-    }
+    assert_route_impl();
 #endif  // NDEBUG
   }
+  void assert_route_impl() const;
 };
 
 }  // namespace masstree

--- a/foedus-core/include/foedus/storage/masstree/masstree_cursor.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_cursor.hpp
@@ -96,7 +96,7 @@ class MasstreeCursor CXX11_FINAL {
     KeySlice latest_separator_;
 
     /** only for border. order_[0] is the index of smallest record, [1] second smallest... */
-    SlotIndex order_[64];
+    SlotIndex order_[kBorderPageMaxSlots];
 
     SlotIndex get_cur_original_index() const ALWAYS_INLINE {
       return order_[index_];
@@ -124,7 +124,7 @@ class MasstreeCursor CXX11_FINAL {
     kCurKeyContains,
   };
   enum Constants {
-    kMaxRecords = 64,
+    kMaxRecords = kBorderPageMaxSlots,
     kMaxRoutes = kPageSize / sizeof(Route),
     kKeyLengthExtremum = 0,
   };

--- a/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
@@ -36,6 +36,33 @@ namespace foedus {
 namespace storage {
 namespace masstree {
 /**
+ * @brief Represents the depth of a B-trie layer. 0 is the first layer.
+ * @ingroup MASSTREE
+ */
+typedef uint8_t Layer;
+
+/**
+ * @brief Maximum value for Layer.
+ * @ingroup MASSTREE
+ */
+const Layer kMaxLayer = 63U;
+
+/**
+ * @brief Represents the depth of a B-tree node in a B-trie layer. 0 is the root.
+ * @ingroup MASSTREE
+ */
+typedef uint8_t InLayerLevel;
+
+/**
+ * @brief If InLayerLevel exceeds this value, there must be something wrong.
+ * @ingroup MASSTREE
+ * @details
+ * In theory, there is no limit on B-tree levels. But, in reality we can't store
+ * 16-levels of B-tree even with the biggest machine in our universe.
+ */
+const InLayerLevel kMaxSaneInLayerLevel = 15U;
+
+/**
  * @brief Represents a byte-length of a key in this package.
  * @ingroup MASSTREE
  */
@@ -209,7 +236,7 @@ inline KeySlice slice_key(const void* be_bytes, uint16_t slice_length) {
  * @return normalized value that preserves the value-order
  * @ingroup MASSTREE
  */
-inline KeySlice slice_layer(const void* be_bytes, KeyLength key_length, uint8_t current_layer) {
+inline KeySlice slice_layer(const void* be_bytes, KeyLength key_length, Layer current_layer) {
   const KeyLength skipped = current_layer * sizeof(KeySlice);
   const KeyLength remainder_length = key_length - skipped;
   const char* casted = reinterpret_cast<const char*>(be_bytes);

--- a/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
@@ -55,10 +55,16 @@ const uint16_t kMaxIntermediatePointers
   = (kMaxIntermediateSeparators + 1U) * (kMaxIntermediateMiniSeparators + 1U);
 
 /**
+ * @brief Represents a byte-length of a key in this package.
+ * @ingroup MASSTREE
+ */
+typedef uint16_t KeyLength;
+
+/**
  * Max length of a key.
  * @ingroup MASSTREE
  */
-const uint16_t kMaxKeyLength = 1024;
+const KeyLength kMaxKeyLength = 1024;
 
 /**
  * @brief Each key slice is an 8-byte integer. Masstree pages store and compare these key slices.

--- a/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
@@ -36,25 +36,6 @@ namespace foedus {
 namespace storage {
 namespace masstree {
 /**
- * Max number of separators stored in the first level of intermediate pages.
- * @ingroup MASSTREE
- */
-const uint8_t kMaxIntermediateSeparators = 9;
-
-/**
- * Max number of separators stored in the second level of intermediate pages.
- * @ingroup MASSTREE
- */
-const uint8_t kMaxIntermediateMiniSeparators = 15;
-
-/**
- * Max number of pointers (if completely filled) stored in an intermediate pages.
- * @ingroup MASSTREE
- */
-const uint16_t kMaxIntermediatePointers
-  = (kMaxIntermediateSeparators + 1U) * (kMaxIntermediateMiniSeparators + 1U);
-
-/**
  * @brief Represents a byte-length of a key in this package.
  * @ingroup MASSTREE
  */
@@ -64,7 +45,40 @@ typedef uint16_t KeyLength;
  * Max length of a key.
  * @ingroup MASSTREE
  */
-const KeyLength kMaxKeyLength = 1024;
+const KeyLength kMaxKeyLength = 1024U;
+
+/**
+ * A special KeyLength that represents a border-page slot pointing to next layer.
+ * @ingroup MASSTREE
+ */
+const KeyLength kNextLayerKeyLength = -1;
+
+/**
+ * @brief Represents a byte-length of a payload in this package.
+ * @ingroup MASSTREE
+ */
+typedef uint16_t PayloadLength;
+
+/**
+ * Max length of a payload.
+ * @ingroup MASSTREE
+ */
+const PayloadLength kMaxPayloadLength = 1024U;
+
+/**
+ * Byte-offset in a page.
+ * @ingroup MASSTREE
+ */
+typedef uint16_t DataOffset;
+
+/**
+ * Index of a record in a (border) page.
+ * @ingroup MASSTREE
+ */
+typedef uint16_t SlotIndex;
+
+/** Used only for sanity checking. offset of data_ member in MasstreeBorderPage */
+const DataOffset kBorderPageDataPartOffset = 880;
 
 /**
  * @brief Each key slice is an 8-byte integer. Masstree pages store and compare these key slices.

--- a/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
@@ -109,9 +109,6 @@ typedef uint16_t DataOffset;
  */
 typedef uint16_t SlotIndex;
 
-/** Offset of data_ member in MasstreeBorderPage */
-const DataOffset kBorderPageDataPartOffset = 880;
-
 /**
  * @brief Each key slice is an 8-byte integer. Masstree pages store and compare these key slices.
  * @ingroup MASSTREE
@@ -139,6 +136,45 @@ const KeySlice kInfimumSlice = 0;
 // For a fence, sanity check is "slice < high_fence"
 const KeySlice kSupremumSlice = 0xFFFFFFFFFFFFFFFFULL;
 
+/**
+ * Size of the base page class (MasstreePage), which is the common header for
+ * intermediate and border pages placed at the beginning.
+ * @ingroup MASSTREE
+ */
+const uint32_t kCommonPageHeaderSize = 72U;
+
+/**
+ * Misc header attributes specific to MasstreeBorderPage placed after the common header.
+ * @ingroup MASSTREE
+ */
+const uint32_t kBorderPageAdditionalHeaderSize = 8U;
+
+/**
+ * Byte size of one slot in MasstreeBorderPage \e excluding slice information.
+ * @ingroup MASSTREE
+ */
+const uint32_t kBorderPageSlotSize = 32U;
+
+/**
+ * Maximum number of slots in one MasstreeBorderPage.
+ * @ingroup MASSTREE
+ */
+const SlotIndex kBorderPageMaxSlots
+  = (kPageSize - kCommonPageHeaderSize - kBorderPageAdditionalHeaderSize)
+    / (kBorderPageSlotSize + sizeof(KeySlice));
+
+/**
+ * Byte size of the record data part (data_) in MasstreeBorderPage.
+ * @ingroup MASSTREE
+ */
+const uint32_t kBorderPageDataPartSize
+  = kPageSize
+    - kCommonPageHeaderSize
+    - kBorderPageAdditionalHeaderSize
+    - kBorderPageMaxSlots * sizeof(KeySlice);
+
+/** Offset of data_ member in MasstreeBorderPage */
+const DataOffset kBorderPageDataPartOffset = 880;
 /**
  * @brief Order-preserving normalization for primitive key types.
  * @param[in] value the value to normalize

--- a/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
@@ -82,7 +82,7 @@ typedef uint16_t DataOffset;
  */
 typedef uint16_t SlotIndex;
 
-/** Used only for sanity checking. offset of data_ member in MasstreeBorderPage */
+/** Offset of data_ member in MasstreeBorderPage */
 const DataOffset kBorderPageDataPartOffset = 880;
 
 /**

--- a/foedus-core/include/foedus/storage/masstree/masstree_log_types.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_log_types.hpp
@@ -185,8 +185,8 @@ struct MasstreeCommonLogType : public log::RecordLogType {
       // compare the rest with memcmp.
       KeyLength min_length = std::min(left->key_length_, right->key_length_);
       if (min_length > kSliceLen) {
-        KeyLength remaining = min_length - kSliceLen;
-        int key_result = std::memcmp(left_key + kSliceLen, right_key + kSliceLen, remaining);
+        KeyLength remainder = min_length - kSliceLen;
+        int key_result = std::memcmp(left_key + kSliceLen, right_key + kSliceLen, remainder);
         if (key_result != 0) {
           return key_result;
         }
@@ -244,11 +244,11 @@ struct MasstreeInsertLogType : public MasstreeCommonLogType {
     ASSERT_ND(equal_record_and_log_suffixes(data));
 
     // In the MasstreeBorderPage Slot, lengthes come right after TID.
-    // [0]: offset, [1]: physical_record_length_, [2]: remaining_key_length_, [3]: payload_length_
+    // [0]: offset, [1]: physical_record_length_, [3]: payload_length_, [4]: remainder_length_
     uint16_t* lengthes = reinterpret_cast<uint16_t*>(owner_id + 1);
     lengthes[3] = payload_count_;
     ASSERT_ND(lengthes[1] >= suffix_length_aligned + assorted::align8(payload_count_));
-    ASSERT_ND(lengthes[2] == key_length_ - (layer * sizeof(KeySlice)));
+    ASSERT_ND(lengthes[4] == key_length_ - (layer * sizeof(KeySlice)));
     ASSERT_ND(reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(data)) % kPageSize
       == static_cast<uint64_t>(lengthes[0] + kBorderPageDataPartOffset));
 
@@ -351,11 +351,11 @@ struct MasstreeUpdateLogType : public MasstreeCommonLogType {
     ASSERT_ND(equal_record_and_log_suffixes(data));
 
     // In the MasstreeBorderPage Slot, lengthes come right after TID.
-    // [0]: offset, [1]: physical_record_length_, [2]: remaining_key_length_, [3]: payload_length_
+    // [0]: offset, [1]: physical_record_length_, [3]: payload_length_, [4]: remainder_length_
     uint16_t* lengthes = reinterpret_cast<uint16_t*>(owner_id + 1);
     lengthes[3] = payload_count_;
     ASSERT_ND(lengthes[1] >= suffix_length_aligned + assorted::align8(payload_count_));
-    ASSERT_ND(lengthes[2] == key_length_ - (layer * sizeof(KeySlice)));
+    ASSERT_ND(lengthes[4] == key_length_ - (layer * sizeof(KeySlice)));
     ASSERT_ND(reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(data)) % kPageSize
       == static_cast<uint64_t>(lengthes[0] + kBorderPageDataPartOffset));
 
@@ -417,11 +417,11 @@ struct MasstreeOverwriteLogType : public MasstreeCommonLogType {
     KeyLength suffix_length_aligned = key_length_aligned - skipped;
 
     // In the MasstreeBorderPage Slot, lengthes come right after TID.
-    // [0]: offset, [1]: physical_record_length_, [2]: remaining_key_length_, [3]: payload_length_
+    // [0]: offset, [1]: physical_record_length_, [3]: payload_length_, [4]: remainder_length_
     uint16_t* lengthes = reinterpret_cast<uint16_t*>(owner_id + 1);
     ASSERT_ND(lengthes[3] >= payload_offset_ + payload_count_);
     ASSERT_ND(lengthes[1] >= suffix_length_aligned + assorted::align8(payload_count_));
-    ASSERT_ND(lengthes[2] == key_length_ - (layer * sizeof(KeySlice)));
+    ASSERT_ND(lengthes[4] == key_length_ - (layer * sizeof(KeySlice)));
     ASSERT_ND(reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(data)) % kPageSize
       == static_cast<uint64_t>(lengthes[0] + kBorderPageDataPartOffset));
 

--- a/foedus-core/include/foedus/storage/masstree/masstree_log_types.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_log_types.hpp
@@ -85,9 +85,9 @@ inline uint8_t extract_page_layer(const void* in_page_pointer) {
  */
 struct MasstreeCommonLogType : public log::RecordLogType {
   LOG_TYPE_NO_CONSTRUCT(MasstreeCommonLogType)
-  uint16_t        key_length_;        // +2 => 18
-  uint16_t        payload_offset_;    // +2 => 20
-  uint16_t        payload_count_;     // +2 => 22
+  KeyLength       key_length_;        // +2 => 18
+  PayloadLength   payload_offset_;    // +2 => 20
+  PayloadLength   payload_count_;     // +2 => 22
   uint16_t        reserved_;          // +2 => 24
   /**
    * Full key and (if exists) payload data, both of which are padded to 8 bytes.
@@ -95,24 +95,26 @@ struct MasstreeCommonLogType : public log::RecordLogType {
    */
   char            aligned_data_[8];   // ~ (+align8(key_length_)+align8(payload_count_))
 
-  static uint16_t calculate_log_length(uint16_t key_length, uint16_t payload_count) ALWAYS_INLINE {
+  static uint16_t calculate_log_length(
+    KeyLength key_length,
+    PayloadLength payload_count) ALWAYS_INLINE {
     return 24U + assorted::align8(key_length) + assorted::align8(payload_count);
   }
 
   char*           get_key() { return aligned_data_; }
   const char*     get_key() const { return aligned_data_; }
   KeySlice        get_first_slice() const { return normalize_be_bytes_full_aligned(aligned_data_); }
-  uint16_t        get_key_length_aligned() const { return assorted::align8(key_length_); }
+  KeyLength       get_key_length_aligned() const { return assorted::align8(key_length_); }
   char*           get_payload() { return aligned_data_ + get_key_length_aligned(); }
   const char*     get_payload() const { return aligned_data_ + get_key_length_aligned(); }
   void            populate_base(
     log::LogCode  type,
     StorageId     storage_id,
     const void*   key,
-    uint16_t      key_length,
+    KeyLength     key_length,
     const void*   payload = CXX11_NULLPTR,
-    uint16_t      payload_offset = 0,
-    uint16_t      payload_count = 0) ALWAYS_INLINE {
+    PayloadLength payload_offset = 0,
+    PayloadLength payload_count = 0) ALWAYS_INLINE {
     header_.log_type_code_ = type;
     header_.log_length_ = calculate_log_length(key_length, payload_count);
     header_.storage_id_ = storage_id;
@@ -122,12 +124,12 @@ struct MasstreeCommonLogType : public log::RecordLogType {
     reserved_ = 0;
 
     std::memcpy(aligned_data_, key, key_length);
-    uint16_t aligned_key_length = assorted::align8(key_length);
+    KeyLength aligned_key_length = assorted::align8(key_length);
     if (aligned_key_length != key_length) {
       std::memset(aligned_data_ + key_length, 0, aligned_key_length - key_length);
     }
     if (payload_count > 0) {
-      uint16_t aligned_payload_count = assorted::align8(payload_count);
+      PayloadLength aligned_payload_count = assorted::align8(payload_count);
       char* payload_base = aligned_data_ + aligned_key_length;
       std::memcpy(payload_base, payload, payload_count);
       if (aligned_payload_count != payload_count) {
@@ -142,11 +144,11 @@ struct MasstreeCommonLogType : public log::RecordLogType {
     // Keys shorter than 8h+8 bytes are stored at layer <= h
     ASSERT_ND(layer <= key_length_ / sizeof(KeySlice));
     // both record and log keep 8-byte padded keys. so we can simply compare keys
-    uint16_t skipped = (layer + 1U) * sizeof(KeySlice);
+    KeyLength skipped = (layer + 1U) * sizeof(KeySlice);
     if (key_length_ > skipped) {
       const char* key = get_key();
-      uint16_t suffix_length = key_length_ - skipped;
-      uint16_t suffix_length_aligned = assorted::align8(suffix_length);
+      KeyLength suffix_length = key_length_ - skipped;
+      KeyLength suffix_length_aligned = assorted::align8(suffix_length);
       // both record and log's suffix keys are 8-byte aligned with zero-padding, so we can
       // compare multiply of 8 bytes
       return std::memcmp(data, key + skipped, suffix_length_aligned) == 0;
@@ -181,9 +183,9 @@ struct MasstreeCommonLogType : public log::RecordLogType {
       }
 
       // compare the rest with memcmp.
-      uint16_t min_length = std::min(left->key_length_, right->key_length_);
+      KeyLength min_length = std::min(left->key_length_, right->key_length_);
       if (min_length > kSliceLen) {
-        uint16_t remaining = min_length - kSliceLen;
+        KeyLength remaining = min_length - kSliceLen;
         int key_result = std::memcmp(left_key + kSliceLen, right_key + kSliceLen, remaining);
         if (key_result != 0) {
           return key_result;
@@ -217,9 +219,9 @@ struct MasstreeInsertLogType : public MasstreeCommonLogType {
   void            populate(
     StorageId   storage_id,
     const void* key,
-    uint16_t    key_length,
+    KeyLength   key_length,
     const void* payload,
-    uint16_t    payload_count) ALWAYS_INLINE {
+    PayloadLength payload_count) ALWAYS_INLINE {
     log::LogCode type = log::kLogCodeMasstreeInsert;
     populate_base(type, storage_id, key, key_length, payload, 0, payload_count);
   }
@@ -233,43 +235,26 @@ struct MasstreeInsertLogType : public MasstreeCommonLogType {
     ASSERT_ND(!owner_id->xct_id_.is_next_layer());
     ASSERT_ND(!owner_id->xct_id_.is_moved());
     uint8_t layer = extract_page_layer(owner_id);
-    uint16_t skipped = (layer + 1U) * sizeof(KeySlice);
-    uint16_t key_length_aligned = get_key_length_aligned();
+    KeyLength skipped = (layer + 1U) * sizeof(KeySlice);
+    KeyLength key_length_aligned = get_key_length_aligned();
     ASSERT_ND(key_length_aligned >= skipped);
+    KeyLength suffix_length_aligned = key_length_aligned - skipped;
     // no need to set key in apply(). it's already set when the record is physically inserted
     // (or in other places if this is recovery).
     ASSERT_ND(equal_record_and_log_suffixes(data));
 
-    // TODO(Hideaki) So far we do a super-dirty trick to set payload_count here.
-    // We will make a major change in page layout to simplify this and a few other things.
-    uintptr_t tid_intptr = reinterpret_cast<uintptr_t>(owner_id);
-    uint16_t tid_offset = reinterpret_cast<uint64_t>(tid_intptr) % kPageSize;
-    ASSERT_ND(tid_offset >= 912U);
-    ASSERT_ND(tid_offset < 1936U);
-    ASSERT_ND(tid_offset % sizeof(xct::LockableXctId) == 0);
-    uint16_t record_index = (tid_offset - 912U) / sizeof(xct::LockableXctId);
-    ASSERT_ND(record_index < 64U);
-
-    uint64_t page_int = reinterpret_cast<uint64_t>(tid_intptr) - tid_offset;
-    ASSERT_ND(page_int % kPageSize == 0);
-    const uint8_t* offset_array = reinterpret_cast<const uint8_t*>(
-      reinterpret_cast<void*>(page_int + 648ULL));
-    const uint8_t* physical_record_length_array = reinterpret_cast<const uint8_t*>(
-      reinterpret_cast<void*>(page_int + 712ULL));
-    uint16_t* payload_length_array = reinterpret_cast<uint16_t*>(
-      reinterpret_cast<void*>(page_int + 776ULL));
-    ASSERT_ND(offset_array[record_index] * 16U == data - reinterpret_cast<char*>(
-      reinterpret_cast<void*>(page_int + 1936ULL)));
-    ASSERT_ND(physical_record_length_array[record_index] * 16U + skipped
-      >= assorted::align8(payload_count_) + key_length_aligned);
-
-    payload_length_array[record_index] = payload_count_;
-
+    // In the MasstreeBorderPage Slot, lengthes come right after TID.
+    // [0]: offset, [1]: physical_record_length_, [2]: remaining_key_length_, [3]: payload_length_
+    uint16_t* lengthes = reinterpret_cast<uint16_t*>(owner_id + 1);
+    lengthes[3] = payload_count_;
+    ASSERT_ND(lengthes[1] >= suffix_length_aligned + assorted::align8(payload_count_));
+    ASSERT_ND(lengthes[2] == key_length_ - (layer * sizeof(KeySlice)));
+    ASSERT_ND(reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(data)) % kPageSize
+      == static_cast<uint64_t>(lengthes[0] + kBorderPageDataPartOffset));
 
     if (payload_count_ > 0U) {
       // record's payload is also 8-byte aligned, so copy multiply of 8 bytes.
       // if the compiler is smart enough, it will do some optimization here.
-      uint16_t suffix_length_aligned = key_length_aligned - skipped;
       void* data_payload = ASSUME_ALIGNED(data + suffix_length_aligned, 8U);
       const void* log_payload = ASSUME_ALIGNED(get_payload(), 8U);
       std::memcpy(data_payload, log_payload, assorted::align8(payload_count_));
@@ -296,14 +281,14 @@ struct MasstreeInsertLogType : public MasstreeCommonLogType {
 struct MasstreeDeleteLogType : public MasstreeCommonLogType {
   LOG_TYPE_NO_CONSTRUCT(MasstreeDeleteLogType)
 
-  static uint16_t calculate_log_length(uint16_t key_length) ALWAYS_INLINE {
+  static uint16_t calculate_log_length(KeyLength key_length) ALWAYS_INLINE {
     return MasstreeCommonLogType::calculate_log_length(key_length, 0);
   }
 
   void            populate(
     StorageId   storage_id,
     const void* key,
-    uint16_t    key_length) ALWAYS_INLINE {
+    KeyLength   key_length) ALWAYS_INLINE {
     log::LogCode type = log::kLogCodeMasstreeDelete;
     populate_base(type, storage_id, key, key_length);
   }
@@ -341,9 +326,9 @@ struct MasstreeUpdateLogType : public MasstreeCommonLogType {
   void            populate(
     StorageId   storage_id,
     const void* key,
-    uint16_t    key_length,
+    KeyLength   key_length,
     const void* payload,
-    uint16_t    payload_count) ALWAYS_INLINE {
+    PayloadLength payload_count) ALWAYS_INLINE {
     log::LogCode type = log::kLogCodeMasstreeUpdate;
     populate_base(type, storage_id, key, key_length, payload, 0, payload_count);
   }
@@ -357,44 +342,26 @@ struct MasstreeUpdateLogType : public MasstreeCommonLogType {
     ASSERT_ND(!owner_id->xct_id_.is_next_layer());
     ASSERT_ND(!owner_id->xct_id_.is_moved());
     uint8_t layer = extract_page_layer(owner_id);
-    uint16_t skipped = (layer + 1U) * sizeof(KeySlice);
-    uint16_t key_length_aligned = get_key_length_aligned();
+    KeyLength skipped = (layer + 1U) * sizeof(KeySlice);
+    KeyLength key_length_aligned = get_key_length_aligned();
+    KeyLength suffix_length_aligned = key_length_aligned - skipped;
     ASSERT_ND(key_length_aligned >= skipped);
     // no need to set key in apply(). it's already set when the record is physically inserted
     // (or in other places if this is recovery).
     ASSERT_ND(equal_record_and_log_suffixes(data));
 
-    // TODO(Hideaki) So far we do a super-dirty trick to set payload_count here.
-    // We will make a major change in page layout to simplify this and a few other things.
-    // At that point, we can get rid of duplicated code with the insert log.
-    uintptr_t tid_intptr = reinterpret_cast<uintptr_t>(owner_id);
-    uint16_t tid_offset = reinterpret_cast<uint64_t>(tid_intptr) % kPageSize;
-    ASSERT_ND(tid_offset >= 912U);
-    ASSERT_ND(tid_offset < 1936U);
-    ASSERT_ND(tid_offset % sizeof(xct::LockableXctId) == 0);
-    uint16_t record_index = (tid_offset - 912U) / sizeof(xct::LockableXctId);
-    ASSERT_ND(record_index < 64U);
-
-    uint64_t page_int = reinterpret_cast<uint64_t>(tid_intptr) - tid_offset;
-    ASSERT_ND(page_int % kPageSize == 0);
-    const uint8_t* offset_array = reinterpret_cast<const uint8_t*>(
-      reinterpret_cast<void*>(page_int + 648ULL));
-    const uint8_t* physical_record_length_array = reinterpret_cast<const uint8_t*>(
-      reinterpret_cast<void*>(page_int + 712ULL));
-    uint16_t* payload_length_array = reinterpret_cast<uint16_t*>(
-      reinterpret_cast<void*>(page_int + 776ULL));
-    ASSERT_ND(offset_array[record_index] * 16U == data - reinterpret_cast<char*>(
-      reinterpret_cast<void*>(page_int + 1936ULL)));
-    ASSERT_ND(physical_record_length_array[record_index] * 16U + skipped
-      >= assorted::align8(payload_count_) + key_length_aligned);
-
-    payload_length_array[record_index] = payload_count_;
-
+    // In the MasstreeBorderPage Slot, lengthes come right after TID.
+    // [0]: offset, [1]: physical_record_length_, [2]: remaining_key_length_, [3]: payload_length_
+    uint16_t* lengthes = reinterpret_cast<uint16_t*>(owner_id + 1);
+    lengthes[3] = payload_count_;
+    ASSERT_ND(lengthes[1] >= suffix_length_aligned + assorted::align8(payload_count_));
+    ASSERT_ND(lengthes[2] == key_length_ - (layer * sizeof(KeySlice)));
+    ASSERT_ND(reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(data)) % kPageSize
+      == static_cast<uint64_t>(lengthes[0] + kBorderPageDataPartOffset));
 
     if (payload_count_ > 0U) {
       // record's payload is also 8-byte aligned, so copy multiply of 8 bytes.
       // if the compiler is smart enough, it will do some optimization here.
-      uint16_t suffix_length_aligned = key_length_aligned - skipped;
       void* data_payload = ASSUME_ALIGNED(data + suffix_length_aligned, 8U);
       const void* log_payload = ASSUME_ALIGNED(get_payload(), 8U);
       std::memcpy(data_payload, log_payload, assorted::align8(payload_count_));
@@ -423,10 +390,10 @@ struct MasstreeOverwriteLogType : public MasstreeCommonLogType {
   void            populate(
     StorageId   storage_id,
     const void* key,
-    uint16_t    key_length,
+    KeyLength   key_length,
     const void* payload,
-    uint16_t    payload_offset,
-    uint16_t    payload_count) ALWAYS_INLINE {
+    PayloadLength payload_offset,
+    PayloadLength payload_count) ALWAYS_INLINE {
     log::LogCode type = log::kLogCodeMasstreeOverwrite;
     ASSERT_ND(payload_count > 0U);
     ASSERT_ND(key_length > 0U);
@@ -443,13 +410,23 @@ struct MasstreeOverwriteLogType : public MasstreeCommonLogType {
     ASSERT_ND(!owner_id->xct_id_.is_moved());
 
     uint8_t layer = extract_page_layer(owner_id);
-    uint16_t skipped = (layer + 1U) * sizeof(KeySlice);
-    uint16_t key_length_aligned = get_key_length_aligned();
+    KeyLength skipped = (layer + 1U) * sizeof(KeySlice);
+    KeyLength key_length_aligned = get_key_length_aligned();
     ASSERT_ND(equal_record_and_log_suffixes(data));
+
+    KeyLength suffix_length_aligned = key_length_aligned - skipped;
+
+    // In the MasstreeBorderPage Slot, lengthes come right after TID.
+    // [0]: offset, [1]: physical_record_length_, [2]: remaining_key_length_, [3]: payload_length_
+    uint16_t* lengthes = reinterpret_cast<uint16_t*>(owner_id + 1);
+    ASSERT_ND(lengthes[3] >= payload_offset_ + payload_count_);
+    ASSERT_ND(lengthes[1] >= suffix_length_aligned + assorted::align8(payload_count_));
+    ASSERT_ND(lengthes[2] == key_length_ - (layer * sizeof(KeySlice)));
+    ASSERT_ND(reinterpret_cast<uint64_t>(reinterpret_cast<uintptr_t>(data)) % kPageSize
+      == static_cast<uint64_t>(lengthes[0] + kBorderPageDataPartOffset));
 
     ASSERT_ND(payload_count_ > 0U);
     // Unlike insert, we can't assume 8-bytes alignment because of payload_offset
-    uint16_t suffix_length_aligned = key_length_aligned - skipped;
     std::memcpy(data + suffix_length_aligned + payload_offset_, get_payload(), payload_count_);
   }
 

--- a/foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp
@@ -657,10 +657,6 @@ class MasstreeBorderPage final : public MasstreePage {
     }
   };
 
-  enum Constants {
-    /** Max number of keys in this page. TODO replace all occurrences with kBorderPageMaxSlots */
-    kMaxKeys = kBorderPageMaxSlots,
-  };
   /** Used in FindKeyForReserveResult */
   enum MatchType {
     kNotFound = 0,
@@ -1638,7 +1634,7 @@ inline bool MasstreeBorderPage::compare_key(
   SlotIndex index,
   const void* be_key,
   KeyLength key_length) const {
-  ASSERT_ND(index < kMaxKeys);
+  ASSERT_ND(index < kBorderPageMaxSlots);
   KeyLength remainder = key_length - get_layer() * sizeof(KeySlice);
   const KeyLength klen = get_remainder_length(index);
   if (remainder != klen) {
@@ -1737,7 +1733,7 @@ inline bool MasstreeBorderPage::will_conflict(
   SlotIndex index,
   KeySlice slice,
   KeyLength remainder) const {
-  ASSERT_ND(index < kMaxKeys);
+  ASSERT_ND(index < kBorderPageMaxSlots);
   ASSERT_ND(remainder > 0);
   if (slice != get_slice(index)) {
     return false;
@@ -1761,7 +1757,7 @@ inline bool MasstreeBorderPage::will_contain_next_layer(
   SlotIndex index,
   KeySlice slice,
   KeyLength remainder) const {
-  ASSERT_ND(index < kMaxKeys);
+  ASSERT_ND(index < kBorderPageMaxSlots);
   ASSERT_ND(remainder > 0);
   return slice == get_slice(index) && does_point_to_layer(index) && remainder > kSliceLen;
 }

--- a/foedus-core/include/foedus/storage/masstree/masstree_storage.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_storage.hpp
@@ -582,6 +582,17 @@ class MasstreeStorage CXX11_FINAL : public Storage<MasstreeStorageControlBlock> 
    * @todo testcase for this method. TDD? shut up.
    */
   ErrorStack  fatify_first_root(thread::Thread* context, uint32_t desired_count);
+
+  /**
+   * @param[in] layer B-trie layer most border pages would be in.
+   * @param[in] key_length estimated byte size of each key
+   * @param[in] payload_length estimated byte size of each payload
+   * @returns Estimated number of records that fit in one border page.
+   */
+  static SlotIndex estimate_records_per_page(
+    uint8_t layer,
+    KeyLength key_length,
+    PayloadLength payload_length);
 };
 }  // namespace masstree
 }  // namespace storage

--- a/foedus-core/include/foedus/storage/masstree/masstree_storage_pimpl.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_storage_pimpl.hpp
@@ -132,10 +132,10 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
   ErrorCode locate_record(
     thread::Thread* context,
     const void* key,
-    uint16_t key_length,
+    KeyLength key_length,
     bool for_writes,
     MasstreeBorderPage** out_page,
-    uint8_t* record_index,
+    SlotIndex* record_index,
     xct::XctId* observed);
   /** Identifies page and record for the normalized key */
   ErrorCode locate_record_normalized(
@@ -143,7 +143,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     KeySlice key,
     bool for_writes,
     MasstreeBorderPage** out_page,
-    uint8_t* record_index,
+    SlotIndex* record_index,
     xct::XctId* observed);
 
   /**
@@ -196,7 +196,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     PayloadLength payload_count,
     PayloadLength physical_payload_hint,
     MasstreeBorderPage** out_page,
-    uint8_t* record_index,
+    SlotIndex* record_index,
     xct::XctId* observed);
   ErrorCode reserve_record_normalized(
     thread::Thread* context,
@@ -204,7 +204,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     PayloadLength payload_count,
     PayloadLength physical_payload_hint,
     MasstreeBorderPage** out_page,
-    uint8_t* record_index,
+    SlotIndex* record_index,
     xct::XctId* observed);
   ErrorCode reserve_record_new_record(
     thread::Thread* context,
@@ -214,7 +214,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     const void* suffix,
     PayloadLength payload_count,
     MasstreeBorderPage** out_page,
-    uint8_t* record_index,
+    SlotIndex* record_index,
     xct::XctId* observed);
   void      reserve_record_new_record_apply(
     thread::Thread* context,
@@ -230,73 +230,73 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
   ErrorCode retrieve_general(
     thread::Thread* context,
     MasstreeBorderPage* border,
-    uint8_t index,
+    SlotIndex index,
     xct::XctId observed,
     void* payload,
-    uint16_t* payload_capacity);
+    PayloadLength* payload_capacity);
   ErrorCode retrieve_part_general(
     thread::Thread* context,
     MasstreeBorderPage* border,
-    uint8_t index,
+    SlotIndex index,
     xct::XctId observed,
     void* payload,
-    uint16_t payload_offset,
-    uint16_t payload_count);
+    PayloadLength payload_offset,
+    PayloadLength payload_count);
 
   /** implementation of insert_record family. use with \b reserve_record() */
   ErrorCode insert_general(
     thread::Thread* context,
     MasstreeBorderPage* border,
-    uint8_t index,
+    SlotIndex index,
     xct::XctId observed,
     const void* be_key,
-    uint16_t key_length,
+    KeyLength key_length,
     const void* payload,
-    uint16_t payload_count);
+    PayloadLength payload_count);
 
   /** implementation of delete_record family. use with locate_record()  */
   ErrorCode delete_general(
     thread::Thread* context,
     MasstreeBorderPage* border,
-    uint8_t index,
+    SlotIndex index,
     xct::XctId observed,
     const void* be_key,
-    uint16_t key_length);
+    KeyLength key_length);
 
   /** implementation of upsert_record family. use with \b reserve_record() */
   ErrorCode upsert_general(
     thread::Thread* context,
     MasstreeBorderPage* border,
-    uint8_t index,
+    SlotIndex index,
     xct::XctId observed,
     const void* be_key,
-    uint16_t key_length,
+    KeyLength key_length,
     const void* payload,
-    uint16_t payload_count);
+    PayloadLength payload_count);
 
   /** implementation of overwrite_record family. use with locate_record()  */
   ErrorCode overwrite_general(
     thread::Thread* context,
     MasstreeBorderPage* border,
-    uint8_t index,
+    SlotIndex index,
     xct::XctId observed,
     const void* be_key,
-    uint16_t key_length,
+    KeyLength key_length,
     const void* payload,
-    uint16_t payload_offset,
-    uint16_t payload_count);
+    PayloadLength payload_offset,
+    PayloadLength payload_count);
 
   /** implementation of increment_record family. use with locate_record()  */
   template <typename PAYLOAD>
   ErrorCode increment_general(
     thread::Thread* context,
     MasstreeBorderPage* border,
-    uint8_t index,
+    SlotIndex index,
     xct::XctId observed,
     const void* be_key,
-    uint16_t key_length,
+    KeyLength key_length,
     PAYLOAD* value,
-    uint16_t payload_offset);
+    PayloadLength payload_offset);
 
   /** These are defined in masstree_storage_verify.cpp */
   ErrorStack verify_single_thread(thread::Thread* context);
@@ -344,7 +344,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     thread::Thread* context,
     bool for_writes,
     MasstreeBorderPage* parent,
-    uint8_t record_index,
+    SlotIndex record_index,
     MasstreePage** page) ALWAYS_INLINE;
 
   /**
@@ -354,7 +354,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
   ErrorCode create_next_layer(
     thread::Thread* context,
     MasstreeBorderPage* parent,
-    uint8_t parent_index);
+    SlotIndex parent_index);
 
   /** defined in masstree_storage_prefetch.cpp */
   ErrorCode prefetch_pages_normalized(

--- a/foedus-core/include/foedus/storage/masstree/masstree_storage_pimpl.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_storage_pimpl.hpp
@@ -225,6 +225,22 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     const void* suffix,
     PayloadLength payload_count,
     xct::XctId* observed);
+  /**
+   * Subroutine of reserve_record() to create an initially next-layer record in border and
+   * returns the new root page of the new layer.
+   * @pre border must be locked by this thread
+   * @pre !border->is_moved()
+   */
+  ErrorCode reserve_record_next_layer(
+    thread::Thread* context,
+    MasstreeBorderPage* border,
+    KeySlice slice,
+    MasstreePage** out_page);
+  ErrorCode reserve_record_next_layer_apply(
+    thread::Thread* context,
+    MasstreeBorderPage* target,
+    KeySlice slice,
+    MasstreePage** out_page);
 
   /** implementation of get_record family. use with locate_record() */
   ErrorCode retrieve_general(

--- a/foedus-core/include/foedus/storage/masstree/masstree_storage_pimpl.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_storage_pimpl.hpp
@@ -210,7 +210,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     thread::Thread* context,
     MasstreeBorderPage* border,
     KeySlice key,
-    KeyLength remaining,
+    KeyLength remainder,
     const void* suffix,
     PayloadLength payload_count,
     MasstreeBorderPage** out_page,
@@ -221,7 +221,7 @@ class MasstreeStoragePimpl final : public Attachable<MasstreeStorageControlBlock
     MasstreeBorderPage* target,
     SlotIndex target_index,
     KeySlice slice,
-    KeyLength remaining_key_length,
+    KeyLength remainder_length,
     const void* suffix,
     PayloadLength payload_count,
     xct::XctId* observed);

--- a/foedus-core/include/foedus/storage/masstree/namespace-info.hpp
+++ b/foedus-core/include/foedus/storage/masstree/namespace-info.hpp
@@ -22,6 +22,63 @@
  * @namespace foedus::storage::masstree
  * @brief \b Masstree Storage, 64-bit B-tries with internal B-trees.
  * @details
+ * Although the package name says masstree [YANDONG12], we call our implementation \e Master-Tree.
+ * There are a few differences from the original Masstree.
+ *
+ * @section MASS_FOSTER_TWIN Foster-Twin
+ * See our paper (lame, yes).
+ *
+ * @section MASS_TERM_REMAINDER Remainder vs Remaining Key
+ * Througout our code, we always use the word \b remainder rather than \b remaining-key.
+ * In [YANDONG12] and [TU13], the word \e remaining-key meant the leftover of
+ * the entire key after removing the common prefixes in previous B-trie layers.
+ * For example, key "abcd" has remaining key "abcd" in layer-0.
+ * key "abcd12345678" has remaining keys "abcd12345678" in layer-0 and "5678" in layer-1.
+ * When the \e length of remaining-key is more than 8-bytes, the page also stores \e suffix,
+ * which is the key part after the slice in the layer.
+ * For example, "abcd12345678" stores "5678" as suffix in layer-0 while no suffix in layer-1.
+ *
+ * Up to here, there is no difference between \e remainder and \e remaining-key.
+ * Actually, in most cases they are exactly the same.
+ *
+ * They differ only when a record points to next layer.
+ * In the original papers/codes, the length of remaining-key is set to be 255 when
+ * the record now points to next layer, and they also overwrite the area to store suffix
+ * with next-page pointer.
+ *
+ * In Master-Tree, we always keep the remainder even when now it points to the next layer.
+ * This simplifies many concurrency control issues, especially our foster-twin tracking algorithm.
+ * Therefore, we never change the length of remainder. It's an immutable property of the record.
+ * Instead, we have an additional mutable boolean flag "next_layer" \b in \b TID.
+ * Whether the next_layer flag is ON or OFF, all threads are safe to access the remainder.
+ * The commit protocol checks the flag and aborts if it's unexpectedly ON.
+ *
+ * This is just a subtle difference, but allthemore subtle, it's confusing!
+ * Hence, we use a different word, \e remainder.
+ * Below we summarize the differences:
+ *
+ * <table>
+ * <tr><th>.</th><th>Remaining Key (Mass-Tree)</th><th>Remainder (Master-Tree)</th></tr>
+ * <tr>
+ *   <td>Length</td>
+ *   <td>Full key length - layer*8 if not next-layer, 255 if it's now next-layer.</td>
+ *   <td>Full key length - layer*8 always. Keeps the original remainder length.</td>
+ * </tr>
+ * <tr>
+ *   <td>Suffix stored at</td>
+ *   <td>The beginning of data region if not next-layer, overwritten if it's now next-layer.</td>
+ *   <td>The beginning of data region always. Keeps the original remainder.</td>
+ * </tr>
+ * <tr>
+ *   <td>Length 0xFFFF means</td>
+ *   <td>The record is now next-layer, so the record has no suffix-region. \b HOWEVER,
+ * concurrent threads must be careful because it was not 0xFFFF before.</td>
+ *   <td>The record was initially next-layer as of creation, so the record has no suffix-region.
+ * Such a record is never moved. A record that later turned to be next-layer doesn't use this value.
+ * </td>
+ * </tr>
+ * </table>
+ *
  * @section MASS_REF References
  * \li [YANDONG12] Yandong Mao, Eddie Kohler, and Robert Tappan Morris.
  *   "Cache craftiness for fast multicore key-value storage.", EuroSys, 2012.

--- a/foedus-core/include/foedus/storage/page.hpp
+++ b/foedus-core/include/foedus/storage/page.hpp
@@ -194,6 +194,16 @@ STATIC_SIZE_CHECK(sizeof(PageVersion), 8)
 struct PageVersionLockScope {
   PageVersionLockScope(thread::Thread* context, PageVersion* version, bool non_racy_lock = false);
   ~PageVersionLockScope() { release(); }
+
+  /**
+   * Convert an existing McsLockScope on page-version to this object.
+   * This is a tentative solution. Now that page-version doesn't need version counter,
+   * we should be able to use McsLockScope everywhere.
+   * @pre move_from->is_locked()
+   * @post !move_from->is_locked() (we steal the lock from the arg)
+   */
+  explicit PageVersionLockScope(xct::McsLockScope* move_from);
+
   void set_changed() { changed_ = true; }
   void release();
 

--- a/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
@@ -42,6 +42,9 @@ namespace sequential {
  * @details
  * In \ref SEQUENTIAL, every data page is a leaf page that forms a singly linked list. So simple.
  *
+ * @par Page Layout
+ * See @ref SEQ_LAYOUT
+ *
  * This is a private implementation-details of \ref SEQUENTIAL, thus file name ends with _impl.
  * Do not include this header from a client program unless you know what you are doing.
  * @attention Do NOT instantiate this object or derive from this class.

--- a/foedus-core/include/foedus/xct/xct_id.hpp
+++ b/foedus-core/include/foedus/xct/xct_id.hpp
@@ -29,6 +29,7 @@
 #include "foedus/assorted/atomic_fences.hpp"
 #include "foedus/assorted/endianness.hpp"
 #include "foedus/assorted/raw_atomics.hpp"
+#include "foedus/storage/fwd.hpp"
 #include "foedus/thread/fwd.hpp"
 #include "foedus/thread/thread_id.hpp"
 
@@ -503,6 +504,9 @@ struct McsLockScope {
   void acquire(bool non_racy_acquire);
   /** Release the lock if acquired. Does nothing if not or !is_valid(). */
   void release();
+
+  /** Just for PageVersionLockScope(McsLockScope*) */
+  void move_to(storage::PageVersionLockScope* new_owner);
 
  private:
   thread::Thread* context_;

--- a/foedus-core/include/foedus/xct/xct_id.hpp
+++ b/foedus-core/include/foedus/xct/xct_id.hpp
@@ -334,6 +334,10 @@ struct XctId {
     ASSERT_ND(ordinal <= kMaxXctOrdinal);
     data_ = (data_ & (~kXctIdMaskOrdinal)) | ordinal;
   }
+  void      increment_ordinal() ALWAYS_INLINE {
+    uint32_t ordinal = get_ordinal();
+    set_ordinal(ordinal + 1U);
+  }
   /**
    * Returns -1, 0, 1 when this is less than, same, larger than other in terms of epoch/ordinal
    * @pre this->is_valid(), other.is_valid()
@@ -465,14 +469,46 @@ struct LockableXctId {
   friend std::ostream& operator<<(std::ostream& o, const LockableXctId& v);
 };
 
+/**
+ * @brief Auto-release object for MCS locking.
+ * @ingroup XCT
+ */
 struct McsLockScope {
-  McsLockScope(thread::Thread* context, LockableXctId* lock);
-  McsLockScope(thread::Thread* context, McsLock* lock);
+  McsLockScope();
+  McsLockScope(
+    thread::Thread* context,
+    LockableXctId* lock,
+    bool acquire_now = true,
+    bool non_racy_acquire = false);
+  McsLockScope(
+    thread::Thread* context,
+    McsLock* lock,
+    bool acquire_now = true,
+    bool non_racy_acquire = false);
   ~McsLockScope();
 
+  /// scope object is movable, but not copiable.
+  McsLockScope(const McsLockScope& other) CXX11_FUNC_DELETE;
+#ifndef DISABLE_CXX11_IN_PUBLIC_HEADERS
+  McsLockScope(McsLockScope&& other);
+  McsLockScope& operator=(McsLockScope&& other);
+#endif  // DISABLE_CXX11_IN_PUBLIC_HEADERS
+
+  void initialize(thread::Thread* context, McsLock* lock, bool acquire_now, bool non_racy_acquire);
+
+  bool is_valid() const { return lock_; }
+  bool is_locked() const { return block_ != 0; }
+
+  /** Acquires the lock. Does nothing if already acquired or !is_valid(). */
+  void acquire(bool non_racy_acquire);
+  /** Release the lock if acquired. Does nothing if not or !is_valid(). */
+  void release();
+
+ private:
   thread::Thread* context_;
-  McsLock* lock_;
-  McsBlockIndex block_;
+  McsLock*        lock_;
+  /** Non-0 when locked. 0 when already released or not yet acquired. */
+  McsBlockIndex   block_;
 };
 
 /** Result of track_moved_record(). When failed to track, both null. */

--- a/foedus-core/include/foedus/xct/xct_id.hpp
+++ b/foedus-core/include/foedus/xct/xct_id.hpp
@@ -375,7 +375,10 @@ struct XctId {
   void    set_deleted() ALWAYS_INLINE { data_ |= kXctIdDeletedBit; }
   void    set_notdeleted() ALWAYS_INLINE { data_ &= (~kXctIdDeletedBit); }
   void    set_moved() ALWAYS_INLINE { data_ |= kXctIdMovedBit; }
-  void    set_next_layer() ALWAYS_INLINE { data_ |= kXctIdNextLayerBit; }
+  void    set_next_layer() ALWAYS_INLINE {
+    // Delete-bit has no meaning for a next-layer record. To avoid confusion, turn it off.
+    data_ = (data_ & (~kXctIdDeletedBit)) | kXctIdNextLayerBit;
+  }
   // note, we should not need this method because becoming a next-layer-pointer is permanent.
   // we never revert it, which simplifies a concurrency control.
   // void    set_not_next_layer() ALWAYS_INLINE { data_ &= (~kXctIdNextLayerBit); }

--- a/foedus-core/src/foedus/engine_options.cpp
+++ b/foedus-core/src/foedus/engine_options.cpp
@@ -321,6 +321,7 @@ void EngineOptions::calculate_required_memory(
   uint64_t kMaxXmlSize = 1ULL << 22;
   *shared_bytes += soc::SharedMemoryRepo::calculate_global_memory_size(kMaxXmlSize, *this);
   *shared_bytes += soc::SharedMemoryRepo::calculate_node_memory_size(*this) * nodes;
+  *shared_bytes += (static_cast<uint64_t>(memory_.page_pool_size_mb_per_node_) << 20) * nodes;
 
   // Then, local memories, which are allocated in various places, so
   // we need to list up each of them.. maybe missing something.

--- a/foedus-core/src/foedus/storage/masstree/masstree_composer_impl.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_composer_impl.cpp
@@ -45,7 +45,7 @@ namespace foedus {
 namespace storage {
 namespace masstree {
 
-inline void fill_payload_padded(char* destination, const char* source, uint16_t count) {
+inline void fill_payload_padded(char* destination, const char* source, PayloadLength count) {
   if (count > 0) {
     ASSERT_ND(is_key_aligned_and_zero_padded(source, count));
     std::memcpy(destination, source, assorted::align8(count));
@@ -137,9 +137,9 @@ ErrorStack MasstreeComposer::construct_root(const Composer::ConstructRootArgumen
     }
 
     uint16_t updated_count = 0;
-    for (uint16_t i = 0; i <= base->get_key_count(); ++i) {
+    for (SlotIndex i = 0; i <= base->get_key_count(); ++i) {
       MasstreeIntermediatePage::MiniPage& base_mini = base->get_minipage(i);
-      for (uint16_t j = 0; j <= base_mini.key_count_; ++j) {
+      for (SlotIndex j = 0; j <= base_mini.key_count_; ++j) {
         SnapshotPagePointer base_pointer = base_mini.pointers_[j].snapshot_pointer_;
         if (from_this_snapshot(base_pointer, args)) {
           ++updated_count;
@@ -205,7 +205,7 @@ ErrorStack MasstreeComposer::construct_root(const Composer::ConstructRootArgumen
 ErrorStack MasstreeComposer::check_buddies(const Composer::ConstructRootArguments& args) const {
   const MasstreeIntermediatePage* base
     = reinterpret_cast<const MasstreeIntermediatePage*>(args.root_info_pages_[0]);
-  const uint16_t key_count = base->header().key_count_;
+  const SlotIndex key_count = base->header().key_count_;
   const uint32_t buddy_count = args.root_info_pages_count_;
   // check key_count
   for (uint16_t buddy = 1; buddy < buddy_count; ++buddy) {
@@ -224,9 +224,9 @@ ErrorStack MasstreeComposer::check_buddies(const Composer::ConstructRootArgument
   }
 
   // check inside minipages
-  for (uint16_t i = 0; i <= key_count; ++i) {
+  for (SlotIndex i = 0; i <= key_count; ++i) {
     const MasstreeIntermediatePage::MiniPage& base_mini = base->get_minipage(i);
-    uint16_t mini_count = base_mini.key_count_;
+    SlotIndex mini_count = base_mini.key_count_;
     // check separator
     for (uint16_t buddy = 1; buddy < buddy_count; ++buddy) {
       const MasstreeIntermediatePage* page
@@ -239,7 +239,7 @@ ErrorStack MasstreeComposer::check_buddies(const Composer::ConstructRootArgument
       }
     }
     // check individual separator and pointers
-    for (uint16_t j = 0; j <= mini_count; ++j) {
+    for (SlotIndex j = 0; j <= mini_count; ++j) {
       ASSERT_ND(base_mini.pointers_[j].volatile_pointer_.is_null());
       uint16_t updated_by = buddy_count;  // only one should have updated each pointer
       SnapshotPagePointer old_pointer = base_mini.pointers_[j].snapshot_pointer_;
@@ -391,7 +391,7 @@ ErrorStack MasstreeComposeContext::execute() {
       const MasstreeCommonLogType* entry =
         reinterpret_cast<const MasstreeCommonLogType*>(merge_sort_->resolve_sort_position(i));
       const char* key = entry->get_key();
-      uint16_t key_length = entry->key_length_;
+      KeyLength key_length = entry->key_length_;
       ASSERT_ND(key_length > 0);
       if (key_length < debug_prev_length) {
         ASSERT_ND(std::memcmp(debug_prev, key, key_length) <= 0);
@@ -675,9 +675,9 @@ ErrorStack MasstreeComposeContext::execute_same_key_group(uint32_t from, uint32_
   PathLevel* last = get_last_level();
   ASSERT_ND(get_page(last->tail_)->is_border());
   MasstreeBorderPage* page = as_border(get_page(last->tail_));
-  uint16_t key_count = page->get_key_count();
+  SlotIndex key_count = page->get_key_count();
   ASSERT_ND(key_count > 0);
-  uint16_t index = key_count - 1;
+  SlotIndex index = key_count - 1;
   ASSERT_ND(!page->does_point_to_layer(index));
   char* record = page->get_record(index);
 
@@ -801,7 +801,7 @@ ErrorCode MasstreeComposeContext::execute_insert_group_append_loop(
         = reinterpret_cast<const MasstreeInsertLogType*>(ASSUME_ALIGNED(logs[i], 8));
       ASSERT_ND(entry->header_.get_type() == log::kLogCodeMasstreeInsert);
       const char* key = entry->get_key();
-      uint16_t key_length = entry->key_length_;
+      KeyLength key_length = entry->key_length_;
 
 #ifndef NDEBUG
       ASSERT_ND(key_length > cur_layer * sizeof(KeySlice));
@@ -811,13 +811,13 @@ ErrorCode MasstreeComposeContext::execute_insert_group_append_loop(
       }
 #endif  // NDEBUG
 
-      uint16_t remaining_length = key_length - cur_layer * sizeof(KeySlice);
+      KeyLength remainder_length = key_length - cur_layer * sizeof(KeySlice);
       const char* suffix = key + (cur_layer + 1) * sizeof(KeySlice);
       KeySlice slice = normalize_be_bytes_full_aligned(key + cur_layer * sizeof(KeySlice));
       ASSERT_ND(page->within_fences(slice));
-      uint8_t key_count = page->get_key_count();
+      SlotIndex key_count = page->get_key_count();
       ASSERT_ND(key_count == 0 || slice > page->get_slice(key_count - 1));
-      uint16_t payload_count = entry->payload_count_;
+      PayloadLength payload_count = entry->payload_count_;
       const char* payload = entry->get_payload();
       xct::XctId xct_id = entry->header_.xct_id_;
       ASSERT_ND(!merge_sort_->get_base_epoch().is_valid()
@@ -832,7 +832,7 @@ ErrorCode MasstreeComposeContext::execute_insert_group_append_loop(
       //   still almost empty, we ignore the hint. close at 10-18. same thing happens at 20, ...
       // Hence, we ignore hints if kDubiousHintsThreshold previous hints caused too empty pages.
       const uint32_t kDubiousHintsThreshold = 2;  // to tolerate more, increase this.
-      const uint16_t kTooEmptySize = kBorderPageDataPartSize * 2 / 10;
+      const DataOffset kTooEmptySize = kBorderPageDataPartSize * 2 / 10;
       bool page_switch_hinted = false;
       KeySlice hint_suggested_slice = kInfimumSlice;
       if (UNLIKELY(next_hint < hint_count && slice >= hints[next_hint])) {
@@ -857,7 +857,7 @@ ErrorCode MasstreeComposeContext::execute_insert_group_append_loop(
       }
 
       if (UNLIKELY(page_switch_hinted)
-        || UNLIKELY(!page->can_accomodate(key_count, remaining_length, payload_count))) {
+        || UNLIKELY(!page->can_accomodate(key_count, remainder_length, payload_count))) {
         // unlike append_border_newpage(), which is used in the per-log method, this does no
         // page migration. much simpler and faster.
         memory::PagePoolOffset new_offset = allocate_page();
@@ -884,8 +884,8 @@ ErrorCode MasstreeComposeContext::execute_insert_group_append_loop(
         key_count = 0;
       }
 
-      ASSERT_ND(page->can_accomodate(key_count, remaining_length, payload_count));
-      page->reserve_record_space(key_count, xct_id, slice, suffix, remaining_length, payload_count);
+      ASSERT_ND(page->can_accomodate(key_count, remainder_length, payload_count));
+      page->reserve_record_space(key_count, xct_id, slice, suffix, remainder_length, payload_count);
       page->increment_key_count();
       fill_payload_padded(page->get_record_payload(key_count), payload, payload_count);
     }
@@ -920,7 +920,7 @@ uint32_t MasstreeComposeContext::execute_insert_group_get_cur_run(
   const MasstreeBorderPage* page = as_border(tail_page);
   const KeySlice low_fence = page->get_low_fence();
   const KeySlice high_fence = page->get_high_fence();
-  const uint8_t existing_keys = page->get_key_count();
+  const SlotIndex existing_keys = page->get_key_count();
   const KeySlice existing_slice
     = existing_keys == 0 ? kInfimumSlice : page->get_slice(existing_keys - 1);
   ASSERT_ND(last->layer_ == page->get_layer());
@@ -970,7 +970,7 @@ uint32_t MasstreeComposeContext::execute_insert_group_get_cur_run(
         reinterpret_cast<const MasstreeCommonLogType*>(
           merge_sort_->resolve_sort_position(cur + run_count));
       const char* key = entry->get_key();
-      uint16_t key_length = entry->key_length_;
+      KeyLength key_length = entry->key_length_;
       ASSERT_ND(is_key_aligned_and_zero_padded(key, key_length));
       if (key_length <= prefix_count * sizeof(KeySlice)) {
         return run_count;
@@ -1037,7 +1037,7 @@ inline ErrorStack MasstreeComposeContext::execute_a_log(uint32_t cur) {
   const MasstreeCommonLogType* entry =
     reinterpret_cast<const MasstreeCommonLogType*>(merge_sort_->resolve_sort_position(cur));
   const char* key = entry->get_key();
-  uint16_t key_length = entry->key_length_;
+  KeyLength key_length = entry->key_length_;
   ASSERT_ND(key_length > 0);
   ASSERT_ND(cur_path_levels_ == 0 || get_page(get_last_level()->tail_)->is_border());
   ASSERT_ND(is_key_aligned_and_zero_padded(key, key_length));
@@ -1058,14 +1058,14 @@ inline ErrorStack MasstreeComposeContext::execute_a_log(uint32_t cur) {
   }
 
   MasstreeBorderPage* page = as_border(get_page(last->tail_));
-  uint16_t key_count = page->get_key_count();
+  SlotIndex key_count = page->get_key_count();
 
   // we might have to follow next-layer pointers. Check it.
   // notice it's "while", not "if", because we might follow more than one next-layer pointer
   while (key_count > 0
       && key_length > (last->layer_ + 1U) * kSliceLen
       && page->get_slice(key_count - 1) == slice
-      && page->get_remaining_key_length(key_count - 1) > kSliceLen) {
+      && page->get_remainder_length(key_count - 1) > kSliceLen) {
     // then we have to either go next layer.
     if (page->does_point_to_layer(key_count - 1)) {
       // the next layer already exists. just follow it.
@@ -1091,7 +1091,7 @@ inline ErrorStack MasstreeComposeContext::execute_a_log(uint32_t cur) {
   // Now we are sure the tail of the last level is the only relevant record. process the log.
   if (entry->header_.get_type() == log::kLogCodeMasstreeOverwrite) {
     // [Overwrite] simply reuse log.apply
-    uint16_t index = key_count - 1;
+    SlotIndex index = key_count - 1;
     ASSERT_ND(!page->does_point_to_layer(index));
     ASSERT_ND(page->equal_key(index, key, key_length));
     char* record = page->get_record(index);
@@ -1108,7 +1108,7 @@ inline ErrorStack MasstreeComposeContext::execute_a_log(uint32_t cur) {
     if (entry->header_.get_type() == log::kLogCodeMasstreeDelete
       || entry->header_.get_type() == log::kLogCodeMasstreeUpdate) {
       // [Delete/Update] Physically deletes the last record in this page.
-      uint16_t index = key_count - 1;
+      SlotIndex index = key_count - 1;
       ASSERT_ND(!page->does_point_to_layer(index));
       ASSERT_ND(page->equal_key(index, key, key_length));
       page->set_key_count(index);
@@ -1119,7 +1119,7 @@ inline ErrorStack MasstreeComposeContext::execute_a_log(uint32_t cur) {
       // [Insert/Update] next-layer is already handled above, so just append it.
       ASSERT_ND(entry->header_.get_type() == log::kLogCodeMasstreeInsert);
       ASSERT_ND(key_count == 0 || !page->equal_key(key_count - 1, key, key_length));  // no dup
-      uint16_t skip = last->layer_ * kSliceLen;
+      KeyLength skip = last->layer_ * kSliceLen;
       append_border(
         slice,
         entry->header_.xct_id_,
@@ -1170,7 +1170,7 @@ ErrorStack MasstreeComposeContext::init_root() {
   return kRetOk;
 }
 
-ErrorStack MasstreeComposeContext::open_first_level(const char* key, uint16_t key_length) {
+ErrorStack MasstreeComposeContext::open_first_level(const char* key, KeyLength key_length) {
   ASSERT_ND(cur_path_levels_ == 0);
   ASSERT_ND(key_length > 0);
   ASSERT_ND(is_key_aligned_and_zero_padded(key, key_length));
@@ -1223,7 +1223,7 @@ ErrorStack MasstreeComposeContext::open_first_level(const char* key, uint16_t ke
 
 ErrorStack MasstreeComposeContext::open_next_level(
   const char* key,
-  uint16_t key_length,
+  KeyLength key_length,
   MasstreePage* parent,
   KeySlice prefix_slice,
   SnapshotPagePointer* next_page_id) {
@@ -1249,7 +1249,7 @@ ErrorStack MasstreeComposeContext::open_next_level(
 
   SnapshotPagePointer page_id = page_id_base_ + level->head_;
   *next_page_id = page_id;
-  uint16_t skip = level->layer_ * kSliceLen;
+  KeyLength skip = level->layer_ * kSliceLen;
   KeySlice slice = normalize_be_bytes_full_aligned(key + skip);
 
   MasstreePage* target = get_page(level->head_);
@@ -1275,10 +1275,10 @@ ErrorStack MasstreeComposeContext::open_next_level(
   if (original->is_border()) {
     // When this is a border page we might or might not have to go down.
     const MasstreeBorderPage* casted = as_border(original);
-    uint16_t key_count = original->get_key_count();
+    SlotIndex key_count = original->get_key_count();
     auto result = casted->find_key_for_snapshot(slice, key + skip, key_length - skip);
 
-    uint16_t copy_count;
+    SlotIndex copy_count;
     bool go_down = false;
     bool create_layer = false;
     switch (result.match_type_) {
@@ -1311,7 +1311,7 @@ ErrorStack MasstreeComposeContext::open_next_level(
       level->set_no_more_next_original();
     } else {
       level->next_original_slice_ = casted->get_slice(level->next_original_);
-      level->next_original_remaining_ = casted->get_remaining_key_length(level->next_original_);
+      level->next_original_remainder_ = casted->get_remainder_length(level->next_original_);
     }
 
     // now, do we have to go down further?
@@ -1325,7 +1325,7 @@ ErrorStack MasstreeComposeContext::open_next_level(
     // if there are such records, the snapshot page has already done so.
     ASSERT_ND(!level->has_next_original() || level->next_original_slice_ > slice);  // check it
 
-    uint8_t next_layer_index = target_casted->get_key_count() - 1;
+    SlotIndex next_layer_index = target_casted->get_key_count() - 1;
     ASSERT_ND(target_casted->get_slice(next_layer_index) == slice);
     if (create_layer) {
       // this is more complicated. we have to migrate the current record to next layer
@@ -1376,10 +1376,10 @@ ErrorStack MasstreeComposeContext::open_next_level(
 
 void MasstreeComposeContext::open_next_level_create_layer(
   const char* key,
-  uint16_t key_length,
+  KeyLength key_length,
   MasstreeBorderPage* parent,
   KeySlice prefix_slice,
-  uint8_t parent_index) {
+  SlotIndex parent_index) {
   ASSERT_ND(!parent->does_point_to_layer(parent_index));  // not yet a next-layer pointer
   ASSERT_ND(parent->get_slice(parent_index) == prefix_slice);
   ASSERT_ND(key_length > 0);
@@ -1408,13 +1408,13 @@ void MasstreeComposeContext::open_next_level_create_layer(
   // DLOG(INFO) << "eqeqwe2 " << *parent;
 
   // migrate the exiting record from parent.
-  uint16_t remaining_length = parent->get_remaining_key_length(parent_index) - kSliceLen;
+  KeyLength remainder_length = parent->get_remainder_length(parent_index) - kSliceLen;
   const char* parent_suffix = parent->get_record(parent_index);
-  ASSERT_ND(is_key_aligned_and_zero_padded(parent_suffix, remaining_length));
+  ASSERT_ND(is_key_aligned_and_zero_padded(parent_suffix, remainder_length));
   KeySlice slice = normalize_be_bytes_full_aligned(parent_suffix);
   const char* suffix = parent_suffix + kSliceLen;
   const char* payload = parent->get_record_payload(parent_index);
-  uint16_t payload_count = parent->get_payload_length(parent_index);
+  PayloadLength payload_count = parent->get_payload_length(parent_index);
   xct::XctId xct_id = parent->get_owner_id(parent_index)->xct_id_;
 
   // DLOG(INFO) << "eqeqwe3 " << *parent;
@@ -1423,8 +1423,8 @@ void MasstreeComposeContext::open_next_level_create_layer(
   // we move the existing record to a dummy original page here.
   MasstreeBorderPage* original = reinterpret_cast<MasstreeBorderPage*>(get_original(this_level));
   original->initialize_snapshot_page(id_, 0, level->layer_, kInfimumSlice, kSupremumSlice);
-  ASSERT_ND(original->can_accomodate(0, remaining_length, payload_count));
-  original->reserve_record_space(0, xct_id, slice, suffix, remaining_length, payload_count);
+  ASSERT_ND(original->can_accomodate(0, remainder_length, payload_count));
+  original->reserve_record_space(0, xct_id, slice, suffix, remainder_length, payload_count);
   original->increment_key_count();
   fill_payload_padded(original->get_record_payload(0), payload, payload_count);
 
@@ -1434,10 +1434,10 @@ void MasstreeComposeContext::open_next_level_create_layer(
     // as the record is still not supposed to be added, we keep it in the original page
     level->next_original_ = 0;
     level->next_original_slice_ = slice;
-    level->next_original_remaining_ = remaining_length;
+    level->next_original_remainder_ = remainder_length;
   } else {
     // okay, insert it now.
-    target->reserve_record_space(0, xct_id, slice, suffix, remaining_length, payload_count);
+    target->reserve_record_space(0, xct_id, slice, suffix, remainder_length, payload_count);
     target->increment_key_count();
     fill_payload_padded(target->get_record_payload(0), payload, payload_count);
     ASSERT_ND(target->ltgt_key(0, key, key_length) > 0);
@@ -1452,7 +1452,7 @@ void MasstreeComposeContext::open_next_level_create_layer(
 
 inline bool MasstreeComposeContext::does_need_to_adjust_path(
   const char* key,
-  uint16_t key_length) const {
+  KeyLength key_length) const {
   if (cur_path_levels_ == 0) {
     return true;  // the path is empty. need to initialize path
   } else if (!cur_path_[0].contains_key(key, key_length)) {
@@ -1477,12 +1477,12 @@ inline bool MasstreeComposeContext::does_need_to_adjust_path(
 
   // Does the in-layer slice of the key match the current page? if not we have to close them
   // key is 8-bytes padded, so we can simply use normalize_be_bytes_full_aligned
-  uint16_t skip = cur_path_layer * kSliceLen;
+  KeyLength skip = cur_path_layer * kSliceLen;
   KeySlice next_slice = normalize_be_bytes_full_aligned(key + skip);
   return !get_last_level()->contains_slice(next_slice);
 }
 
-ErrorStack MasstreeComposeContext::adjust_path(const char* key, uint16_t key_length) {
+ErrorStack MasstreeComposeContext::adjust_path(const char* key, KeyLength key_length) {
   // Close levels/layers until prefix slice matches
   bool closed_something = false;
   if (cur_path_levels_ > 0) {
@@ -1501,7 +1501,7 @@ ErrorStack MasstreeComposeContext::adjust_path(const char* key, uint16_t key_len
 
     last = get_last_level();
     // Close levels upto fence matches
-    uint16_t skip = last->layer_ * kSliceLen;
+    KeyLength skip = last->layer_ * kSliceLen;
     KeySlice next_slice = normalize_be_bytes_full_aligned(key + skip);
     while (cur_path_levels_ > 0 && !last->contains_slice(next_slice)) {
       // the next key doesn't fit in the current path. need to close.
@@ -1526,7 +1526,7 @@ ErrorStack MasstreeComposeContext::adjust_path(const char* key, uint16_t key_len
   // if it's a border page, we may have to go down, but at this point we are not sure.
   // so, just handle intermediate page case. after doing this, last level should be a border page.
   PathLevel* last = get_last_level();
-  uint16_t skip = last->layer_ * kSliceLen;
+  KeyLength skip = last->layer_ * kSliceLen;
   KeySlice next_slice = normalize_be_bytes_full_aligned(key + skip);
   ASSERT_ND(last->contains_slice(next_slice));
   MasstreePage* page = get_page(last->tail_);
@@ -1545,9 +1545,9 @@ ErrorStack MasstreeComposeContext::adjust_path(const char* key, uint16_t key_len
     ASSERT_ND(casted->find_minipage(next_slice) == casted->get_key_count());
     ASSERT_ND(casted->get_minipage(casted->get_key_count()).find_pointer(next_slice)
       == casted->get_minipage(casted->get_key_count()).key_count_);
-    uint8_t index = casted->get_key_count();
+    SlotIndex index = casted->get_key_count();
     MasstreeIntermediatePage::MiniPage& minipage = casted->get_minipage(index);
-    uint8_t index_mini = minipage.key_count_;
+    SlotIndex index_mini = minipage.key_count_;
 #ifndef NDEBUG
     KeySlice existing_low;
     KeySlice existing_high;
@@ -1566,20 +1566,21 @@ ErrorStack MasstreeComposeContext::adjust_path(const char* key, uint16_t key_len
 inline void MasstreeComposeContext::append_border(
   KeySlice slice,
   xct::XctId xct_id,
-  KeyLength remaining_length,
+  KeyLength remainder_length,
   const char* suffix,
   PayloadLength payload_count,
   const char* payload,
   PathLevel* level) {
-  ASSERT_ND(remaining_length != kNextLayerKeyLength);
+  ASSERT_ND(remainder_length != kInitiallyNextLayer);
+  ASSERT_ND(remainder_length < kMaxKeyLength);
   MasstreeBorderPage* target = as_border(get_page(level->tail_));
   SlotIndex key_count = target->get_key_count();
   SlotIndex new_index = key_count;
-  ASSERT_ND(key_count == 0 || !target->will_conflict(key_count - 1, slice, remaining_length));
+  ASSERT_ND(key_count == 0 || !target->will_conflict(key_count - 1, slice, remainder_length));
   ASSERT_ND(key_count == 0
-    || !target->will_contain_next_layer(key_count - 1, slice, remaining_length));
-  ASSERT_ND(key_count == 0 || target->ltgt_key(key_count - 1, slice, suffix, remaining_length) > 0);
-  if (UNLIKELY(!target->can_accomodate(new_index, remaining_length, payload_count))) {
+    || !target->will_contain_next_layer(key_count - 1, slice, remainder_length));
+  ASSERT_ND(key_count == 0 || target->ltgt_key(key_count - 1, slice, suffix, remainder_length) > 0);
+  if (UNLIKELY(!target->can_accomodate(new_index, remainder_length, payload_count))) {
     append_border_newpage(slice, level);
     MasstreeBorderPage* new_target = as_border(get_page(level->tail_));
     ASSERT_ND(target != new_target);
@@ -1587,7 +1588,7 @@ inline void MasstreeComposeContext::append_border(
     new_index = 0;
   }
 
-  target->reserve_record_space(new_index, xct_id, slice, suffix, remaining_length, payload_count);
+  target->reserve_record_space(new_index, xct_id, slice, suffix, remainder_length, payload_count);
   target->increment_key_count();
   fill_payload_padded(target->get_record_payload(new_index), payload, payload_count);
 }
@@ -1598,8 +1599,8 @@ inline void MasstreeComposeContext::append_border_next_layer(
   SnapshotPagePointer pointer,
   PathLevel* level) {
   MasstreeBorderPage* target = as_border(get_page(level->tail_));
-  uint16_t key_count = target->get_key_count();
-  uint16_t new_index = key_count;
+  SlotIndex key_count = target->get_key_count();
+  SlotIndex new_index = key_count;
   ASSERT_ND(key_count == 0 || !target->will_conflict(key_count - 1, slice, 0xFF));
   ASSERT_ND(key_count == 0 || target->ltgt_key(key_count - 1, slice, nullptr, kSliceLen) > 0);
   if (UNLIKELY(!target->can_accomodate(new_index, 0, sizeof(DualPagePointer)))) {
@@ -1615,7 +1616,7 @@ inline void MasstreeComposeContext::append_border_next_layer(
 
 void MasstreeComposeContext::append_border_newpage(KeySlice slice, PathLevel* level) {
   MasstreeBorderPage* target = as_border(get_page(level->tail_));
-  uint16_t key_count = target->get_key_count();
+  SlotIndex key_count = target->get_key_count();
 
   memory::PagePoolOffset new_offset = allocate_page();
   SnapshotPagePointer new_page_id = page_id_base_ + new_offset;
@@ -1631,29 +1632,29 @@ void MasstreeComposeContext::append_border_newpage(KeySlice slice, PathLevel* le
 
   // We have to make sure the same slice does not span two pages with only length different
   // (masstree protocol). So, we might have to migrate a few more records in rare cases.
-  uint16_t migrate_from;
+  SlotIndex migrate_from;
   for (migrate_from = key_count; target->get_slice(migrate_from - 1U) == slice; --migrate_from) {
     continue;
   }
   if (migrate_from != key_count) {
     LOG(INFO) << "Interesting, migrate records to avoid key slice spanning two pages";
-    for (uint16_t old_index = migrate_from; old_index < key_count; ++old_index) {
+    for (SlotIndex old_index = migrate_from; old_index < key_count; ++old_index) {
       ASSERT_ND(target->get_slice(old_index) == slice);
       xct::XctId xct_id = target->get_owner_id(old_index)->xct_id_;
-      uint16_t new_index = new_target->get_key_count();
+      SlotIndex new_index = new_target->get_key_count();
       if (target->does_point_to_layer(old_index)) {
         const DualPagePointer* pointer = target->get_next_layer(old_index);
         ASSERT_ND(pointer->volatile_pointer_.is_null());
         new_target->append_next_layer_snapshot(xct_id, slice, pointer->snapshot_pointer_);
       } else {
-        uint16_t payload_count = target->get_payload_length(old_index);
-        uint16_t remaining = target->get_remaining_key_length(old_index);
+        PayloadLength payload_count = target->get_payload_length(old_index);
+        KeyLength remainder = target->get_remainder_length(old_index);
         new_target->reserve_record_space(
           new_index,
           xct_id,
           slice,
           target->get_record(old_index),
-          remaining,
+          remainder,
           payload_count);
         new_target->increment_key_count();
         fill_payload_padded(
@@ -1713,7 +1714,7 @@ void MasstreeComposeContext::append_intermediate_newpage_and_pointer(
 
 ErrorStack MasstreeComposeContext::consume_original_upto_border(
   KeySlice slice,
-  uint16_t key_length,
+  KeyLength key_length,
   PathLevel* level) {
   ASSERT_ND(level == get_last_level());  // so far this is the only usecase
   ASSERT_ND(key_length > level->layer_ * kSliceLen);
@@ -1721,13 +1722,13 @@ ErrorStack MasstreeComposeContext::consume_original_upto_border(
   uint16_t level_index = level - cur_path_;
   MasstreeBorderPage* original = as_border(get_original(level_index));
   while (level->needs_to_consume_original(slice, key_length)) {
-    uint16_t index = level->next_original_;
+    SlotIndex index = level->next_original_;
     ASSERT_ND(level->next_original_slice_ == original->get_slice(index));
-    ASSERT_ND(level->next_original_remaining_ == original->get_remaining_key_length(index));
+    ASSERT_ND(level->next_original_remainder_ == original->get_remainder_length(index));
     ASSERT_ND(level->has_next_original());
     ASSERT_ND(level->next_original_slice_ <= slice);
     KeySlice original_slice = original->get_slice(index);
-    uint16_t original_remaining = original->get_remaining_key_length(index);
+    KeyLength original_remainder = original->get_remainder_length(index);
     xct::XctId xct_id = original->get_owner_id(index)->xct_id_;
     if (original->does_point_to_layer(index)) {
       const DualPagePointer* pointer = original->get_next_layer(index);
@@ -1737,7 +1738,7 @@ ErrorStack MasstreeComposeContext::consume_original_upto_border(
       append_border(
         original_slice,
         xct_id,
-        original_remaining,
+        original_remainder,
         original->get_record(index),
         original->get_payload_length(index),
         original->get_record_payload(index),
@@ -1748,7 +1749,7 @@ ErrorStack MasstreeComposeContext::consume_original_upto_border(
       level->set_no_more_next_original();
     } else {
       level->next_original_slice_ = original->get_slice(level->next_original_);
-      level->next_original_remaining_ = original->get_remaining_key_length(level->next_original_);
+      level->next_original_remainder_ = original->get_remainder_length(level->next_original_);
     }
   }
   return kRetOk;
@@ -1789,7 +1790,7 @@ ErrorStack MasstreeComposeContext::consume_original_all() {
   if (page->is_border()) {
     MasstreeBorderPage* original = as_border(page);
     while (last->has_next_original()) {
-      uint16_t index = last->next_original_;
+      SlotIndex index = last->next_original_;
       KeySlice slice = original->get_slice(index);
       xct::XctId xct_id = original->get_owner_id(index)->xct_id_;
       if (original->does_point_to_layer(index)) {
@@ -1800,7 +1801,7 @@ ErrorStack MasstreeComposeContext::consume_original_all() {
         append_border(
           slice,
           xct_id,
-          original->get_remaining_key_length(index),
+          original->get_remainder_length(index),
           original->get_record(index),
           original->get_payload_length(index),
           original->get_record_payload(index),
@@ -1922,9 +1923,9 @@ ErrorStack MasstreeComposeContext::pushup_non_root() {
     bool already_appended = false;
     if (is_head) {
       const MasstreeIntermediatePage* parent_page = as_intermdiate(get_page(parent->tail_));
-      uint8_t index = parent_page->get_key_count();
+      SlotIndex index = parent_page->get_key_count();
       const MasstreeIntermediatePage::MiniPage& mini = parent_page->get_minipage(index);
-      uint16_t index_mini = mini.key_count_;
+      SlotIndex index_mini = mini.key_count_;
       if (mini.pointers_[index_mini].snapshot_pointer_ == pointer) {
         already_appended = true;
 #ifndef NDEBUG
@@ -2503,9 +2504,9 @@ ErrorCode MasstreeComposeContext::install_snapshot_pointers_recurse_border(
   // a record in border page is never physically deleted.
   // also once a record becomes next-layer pointer, it never gets reverted to a usual record.
   // just make sure we put consume (no need to be acquire) fence in a few places.
-  uint8_t key_count = volatile_page->get_key_count();
+  SlotIndex key_count = volatile_page->get_key_count();
   assorted::memory_fence_consume();
-  for (uint8_t i = 0; i < key_count; ++i) {
+  for (SlotIndex i = 0; i < key_count; ++i) {
     if (!volatile_page->does_point_to_layer(i)) {
       continue;
     }
@@ -2669,8 +2670,8 @@ void MasstreeComposer::drop_all_recurse_page_only(
   ASSERT_ND(!page->has_foster_child());
   if (page->is_border()) {
     MasstreeBorderPage* border = as_border(page);
-    const uint8_t key_count = page->get_key_count();
-    for (uint8_t i = 0; i < key_count; ++i) {
+    const SlotIndex key_count = page->get_key_count();
+    for (SlotIndex i = 0; i < key_count; ++i) {
       if (border->does_point_to_layer(i)) {
         DualPagePointer* pointer = border->get_next_layer(i);
         drop_all_recurse(args, pointer);
@@ -2813,8 +2814,8 @@ inline Composer::DropResult MasstreeComposer::drop_volatiles_border(
   }
 
   ASSERT_ND(!page->has_foster_child());
-  const uint8_t key_count = page->get_key_count();
-  for (uint8_t i = 0; i < key_count; ++i) {
+  const SlotIndex key_count = page->get_key_count();
+  for (SlotIndex i = 0; i < key_count; ++i) {
     if (page->does_point_to_layer(i)) {
       DualPagePointer* pointer = page->get_next_layer(i);
       result.combine(drop_volatiles_recurse(args, pointer));

--- a/foedus-core/src/foedus/storage/masstree/masstree_cursor.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_cursor.cpp
@@ -154,11 +154,11 @@ ErrorCode MasstreeCursor::proceed_route_border() {
           cur_key_observed_owner_id_,
           cur_key_owner_id_address));
       }
-      if (cur_key_observed_owner_id_.is_deleted()) {
-        continue;
-      }
+      // If it points to next-layer, we ignore deleted bit. It has no meaning for next-layer rec.
       if (is_cur_key_next_layer()) {
         CHECK_ERROR_CODE(proceed_next_layer());
+      } else if (cur_key_observed_owner_id_.is_deleted()) {
+        continue;
       }
       break;
     } else {

--- a/foedus-core/src/foedus/storage/masstree/masstree_metadata.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_metadata.cpp
@@ -48,6 +48,7 @@ ErrorStack MasstreeMetadataSerializer::load(tinyxml2::XMLElement* element) {
     element,
     "snapshot_drop_volatile_pages_btree_levels_",
     &data_casted_->snapshot_drop_volatile_pages_btree_levels_))
+  CHECK_ERROR(get_element(element, "min_layer_hint_", &data_casted_->min_layer_hint_))
   return kRetOk;
 }
 
@@ -65,6 +66,7 @@ ErrorStack MasstreeMetadataSerializer::save(tinyxml2::XMLElement* element) const
     "snapshot_drop_volatile_pages_btree_levels_",
     "",
     data_casted_->snapshot_drop_volatile_pages_btree_levels_));
+  CHECK_ERROR(add_element(element, "min_layer_hint_", "", data_casted_->min_layer_hint_));
   return kRetOk;
 }
 

--- a/foedus-core/src/foedus/storage/masstree/masstree_page_debug.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_page_debug.cpp
@@ -141,10 +141,14 @@ void MasstreeBorderPage::assert_entries_impl() const {
   for (uint8_t i = 1; i < key_count; ++i) {
     uint8_t pre = order[i - 1];
     uint8_t cur = order[i];
-    ASSERT_ND(slices_[pre] <= slices_[cur]);
-    if (slices_[pre] == slices_[cur]) {
-      ASSERT_ND(remaining_key_length_[pre] < remaining_key_length_[cur]);
-      ASSERT_ND(remaining_key_length_[pre] <= sizeof(KeySlice));
+    const KeySlice pre_slice = get_slice(pre);
+    const KeySlice cur_slice = get_slice(cur);
+    ASSERT_ND(pre_slice <= cur_slice);
+    if (pre_slice == cur_slice) {
+      const uint16_t pre_klen = get_remaining_key_length(pre);
+      const uint16_t cur_klen = get_remaining_key_length(cur);
+      ASSERT_ND(pre_klen < cur_klen);
+      ASSERT_ND(pre_klen <= sizeof(KeySlice));
     }
   }
 

--- a/foedus-core/src/foedus/storage/masstree/masstree_page_debug.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_page_debug.cpp
@@ -81,15 +81,16 @@ std::ostream& operator<<(std::ostream& o, const MasstreeBorderPage& v) {
   for (uint16_t i = 0; i < v.get_key_count(); ++i) {
     o << std::endl << "  <record index=\"" << i
       << "\" slice=\"" << assorted::Hex(v.get_slice(i), 16)
-      << "\" remaining_key_len=\"" << static_cast<int>(v.get_remaining_key_length(i))
+      << "\" remainder_len=\"" << static_cast<int>(v.get_remainder_length(i))
       << "\" offset=\"" << v.get_offset_in_bytes(i)
+      << "\" physical_record_len=\"" << v.get_slot(i)->lengthes_.components.physical_record_length_
       << "\" payload_len=\"" << v.get_payload_length(i)
       << "\">";
     if (v.does_point_to_layer(i)) {
       o << "<next_layer>" << *v.get_next_layer(i) << "</next_layer>";
     } else {
-      if (v.get_remaining_key_length(i) > sizeof(KeySlice)) {
-        std::string suffix(v.get_record(i), v.get_remaining_key_length(i) - sizeof(KeySlice));
+      if (v.get_remainder_length(i) > sizeof(KeySlice)) {
+        std::string suffix(v.get_record(i), v.get_suffix_length(i));
         o << "<key_suffix>" << assorted::HexString(suffix) << "</key_suffix>";
       }
       if (v.get_payload_length(i) > 0) {
@@ -111,42 +112,42 @@ void MasstreeBorderPage::assert_entries_impl() const {
   ASSERT_ND(header_.snapshot_ || is_locked());
   struct Sorter {
     explicit Sorter(const MasstreeBorderPage* target) : target_(target) {}
-    bool operator() (uint8_t left, uint8_t right) {
+    bool operator() (SlotIndex left, SlotIndex right) {
       KeySlice left_slice = target_->get_slice(left);
       KeySlice right_slice = target_->get_slice(right);
       if (left_slice < right_slice) {
         return true;
       } else if (left_slice == right_slice) {
-        return target_->get_remaining_key_length(left) < target_->get_remaining_key_length(right);
+        return target_->get_remainder_length(left) < target_->get_remainder_length(right);
       } else {
         return false;
       }
     }
     const MasstreeBorderPage* target_;
   };
-  uint8_t key_count = get_key_count();
-  uint8_t order[kMaxKeys];
-  for (uint8_t i = 0; i < key_count; ++i) {
+  SlotIndex key_count = get_key_count();
+  SlotIndex order[kBorderPageMaxSlots];
+  for (SlotIndex i = 0; i < key_count; ++i) {
     order[i] = i;
   }
   std::sort(order, order + key_count, Sorter(this));
 
   if (header_.snapshot_) {
     // in snapshot page, all entries should be fully sorted
-    for (uint8_t i = 0; i < key_count; ++i) {
+    for (SlotIndex i = 0; i < key_count; ++i) {
       ASSERT_ND(order[i] == i);
     }
   }
 
-  for (uint8_t i = 1; i < key_count; ++i) {
-    uint8_t pre = order[i - 1];
-    uint8_t cur = order[i];
+  for (SlotIndex i = 1; i < key_count; ++i) {
+    SlotIndex pre = order[i - 1];
+    SlotIndex cur = order[i];
     const KeySlice pre_slice = get_slice(pre);
     const KeySlice cur_slice = get_slice(cur);
     ASSERT_ND(pre_slice <= cur_slice);
     if (pre_slice == cur_slice) {
-      const uint16_t pre_klen = get_remaining_key_length(pre);
-      const uint16_t cur_klen = get_remaining_key_length(cur);
+      const KeyLength pre_klen = get_remainder_length(pre);
+      const KeyLength cur_klen = get_remainder_length(cur);
       ASSERT_ND(pre_klen < cur_klen);
       ASSERT_ND(pre_klen <= sizeof(KeySlice));
     }
@@ -154,24 +155,24 @@ void MasstreeBorderPage::assert_entries_impl() const {
 
   // also check the padding between key suffix and payload
   if (header_.snapshot_) {  // this can't be checked in volatile pages that are being changed
-    for (uint8_t i = 0; i < key_count; ++i) {
+    for (SlotIndex i = 0; i < key_count; ++i) {
       if (does_point_to_layer(i)) {
         continue;
       }
-      uint16_t suffix_length = get_suffix_length(i);
-      uint16_t suffix_length_aligned = get_suffix_length_aligned(i);
+      KeyLength suffix_length = get_suffix_length(i);
+      KeyLength suffix_length_aligned = get_suffix_length_aligned(i);
       if (suffix_length > 0 && suffix_length != suffix_length_aligned) {
         ASSERT_ND(suffix_length_aligned > suffix_length);
-        for (uint16_t pos = suffix_length; pos < suffix_length_aligned; ++pos) {
+        for (KeyLength pos = suffix_length; pos < suffix_length_aligned; ++pos) {
           // must be zero-padded
           ASSERT_ND(get_record(i)[pos] == 0);
         }
       }
-      uint16_t payload_length = get_payload_length(i);
-      uint16_t payload_length_aligned = assorted::align8(payload_length);
+      PayloadLength payload_length = get_payload_length(i);
+      PayloadLength payload_length_aligned = assorted::align8(payload_length);
       if (payload_length > 0 && payload_length != payload_length_aligned) {
         ASSERT_ND(payload_length_aligned > payload_length);
-        for (uint16_t pos = payload_length; pos < payload_length_aligned; ++pos) {
+        for (PayloadLength pos = payload_length; pos < payload_length_aligned; ++pos) {
           // must be zero-padded
           ASSERT_ND(get_record(i)[suffix_length_aligned + pos] == 0);
         }

--- a/foedus-core/src/foedus/storage/masstree/masstree_page_impl.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_page_impl.cpp
@@ -269,7 +269,7 @@ void MasstreeBorderPage::release_pages_recursive(
     }
   } else {
     SlotIndex key_count = get_key_count();
-    ASSERT_ND(key_count <= kMaxKeys);
+    ASSERT_ND(key_count <= kBorderPageMaxSlots);
     for (SlotIndex i = 0; i < key_count; ++i) {
       if (does_point_to_layer(i)) {
         DualPagePointer* pointer = get_next_layer(i);

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
@@ -81,6 +81,12 @@ ErrorCode MasstreeStorage::get_record(
   KeyLength key_length,
   void* payload,
   PayloadLength* payload_capacity) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return get_record_normalized(context, slice, payload, payload_capacity);
+  }
+
   MasstreeBorderPage* border;
   SlotIndex index;
   xct::XctId observed;
@@ -109,6 +115,12 @@ ErrorCode MasstreeStorage::get_record_part(
   void* payload,
   PayloadLength payload_offset,
   PayloadLength payload_count) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return get_record_part_normalized(context, slice, payload, payload_offset, payload_count);
+  }
+
   MasstreeBorderPage* border;
   SlotIndex index;
   xct::XctId observed;
@@ -138,6 +150,12 @@ ErrorCode MasstreeStorage::get_record_primitive(
   KeyLength key_length,
   PAYLOAD* payload,
   PayloadLength payload_offset) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return get_record_primitive_normalized<PAYLOAD>(context, slice, payload, payload_offset);
+  }
+
   MasstreeBorderPage* border;
   SlotIndex index;
   xct::XctId observed;
@@ -260,6 +278,12 @@ ErrorCode MasstreeStorage::insert_record(
   const void* payload,
   PayloadLength payload_count,
   PayloadLength physical_payload_hint) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return insert_record_normalized(context, slice, payload, payload_count, physical_payload_hint);
+  }
+
   if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
@@ -326,6 +350,12 @@ ErrorCode MasstreeStorage::delete_record(
   thread::Thread* context,
   const void* key,
   KeyLength key_length) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return delete_record_normalized(context, slice);
+  }
+
   MasstreeBorderPage* border;
   SlotIndex index;
   xct::XctId observed;
@@ -367,6 +397,12 @@ ErrorCode MasstreeStorage::upsert_record(
   const void* payload,
   PayloadLength payload_count,
   PayloadLength physical_payload_hint) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return upsert_record_normalized(context, slice, payload, payload_count, physical_payload_hint);
+  }
+
   if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
@@ -436,6 +472,12 @@ ErrorCode MasstreeStorage::overwrite_record(
   const void* payload,
   PayloadLength payload_offset,
   PayloadLength payload_count) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return overwrite_record_normalized(context, slice, payload, payload_offset, payload_count);
+  }
+
   MasstreeBorderPage* border;
   SlotIndex index;
   xct::XctId observed;
@@ -467,6 +509,12 @@ ErrorCode MasstreeStorage::overwrite_record_primitive(
   KeyLength key_length,
   PAYLOAD payload,
   PayloadLength payload_offset) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return overwrite_record_primitive_normalized<PAYLOAD>(context, slice, payload, payload_offset);
+  }
+
   MasstreeBorderPage* border;
   SlotIndex index;
   xct::XctId observed;
@@ -558,6 +606,12 @@ ErrorCode MasstreeStorage::increment_record(
   KeyLength key_length,
   PAYLOAD* value,
   PayloadLength payload_offset) {
+  // Automatically switch to faster implementation for 8-byte keys
+  if (key_length == sizeof(KeySlice)) {
+    KeySlice slice = normalize_be_bytes_full(key);
+    return increment_record_normalized<PAYLOAD>(context, slice, value, payload_offset);
+  }
+
   MasstreeBorderPage* border;
   SlotIndex index;
   xct::XctId observed;
@@ -641,7 +695,7 @@ ErrorStack MasstreeStorage::fatify_first_root(thread::Thread* context, uint32_t 
 }
 
 SlotIndex MasstreeStorage::estimate_records_per_page(
-  uint8_t layer,
+  Layer layer,
   KeyLength key_length,
   PayloadLength payload_length) {
   PayloadLength aligned_payload = assorted::align8(payload_length);

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
@@ -78,11 +78,11 @@ std::ostream& operator<<(std::ostream& o, const MasstreeStorage& v) {
 ErrorCode MasstreeStorage::get_record(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   void* payload,
-  uint16_t* payload_capacity) {
+  PayloadLength* payload_capacity) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record(
@@ -105,12 +105,12 @@ ErrorCode MasstreeStorage::get_record(
 ErrorCode MasstreeStorage::get_record_part(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   void* payload,
-  uint16_t payload_offset,
-  uint16_t payload_count) {
+  PayloadLength payload_offset,
+  PayloadLength payload_count) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record(
@@ -135,11 +135,11 @@ template <typename PAYLOAD>
 ErrorCode MasstreeStorage::get_record_primitive(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   PAYLOAD* payload,
-  uint16_t payload_offset) {
+  PayloadLength payload_offset) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record(
@@ -164,9 +164,9 @@ ErrorCode MasstreeStorage::get_record_normalized(
   thread::Thread* context,
   KeySlice key,
   void* payload,
-  uint16_t* payload_capacity) {
+  PayloadLength* payload_capacity) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record_normalized(
@@ -189,10 +189,10 @@ ErrorCode MasstreeStorage::get_record_part_normalized(
   thread::Thread* context,
   KeySlice key,
   void* payload,
-  uint16_t payload_offset,
-  uint16_t payload_count) {
+  PayloadLength payload_offset,
+  PayloadLength payload_count) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record_normalized(
@@ -217,9 +217,9 @@ ErrorCode MasstreeStorage::get_record_primitive_normalized(
   thread::Thread* context,
   KeySlice key,
   PAYLOAD* payload,
-  uint16_t payload_offset) {
+  PayloadLength payload_offset) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record_normalized(
@@ -239,7 +239,9 @@ ErrorCode MasstreeStorage::get_record_primitive_normalized(
     sizeof(PAYLOAD));
 }
 
-uint16_t adjust_payload_hint(uint16_t payload_count, uint16_t physical_payload_hint) {
+PayloadLength adjust_payload_hint(
+  PayloadLength payload_count,
+  PayloadLength physical_payload_hint) {
   ASSERT_ND(physical_payload_hint >= payload_count);  // if not, most likely misuse.
   if (physical_payload_hint < payload_count) {
     physical_payload_hint = payload_count;
@@ -254,16 +256,16 @@ uint16_t adjust_payload_hint(uint16_t payload_count, uint16_t physical_payload_h
 ErrorCode MasstreeStorage::insert_record(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   const void* payload,
-  uint16_t payload_count,
-  uint16_t physical_payload_hint) {
+  PayloadLength payload_count,
+  PayloadLength physical_payload_hint) {
   if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.reserve_record(
@@ -290,14 +292,14 @@ ErrorCode MasstreeStorage::insert_record_normalized(
   thread::Thread* context,
   KeySlice key,
   const void* payload,
-  uint16_t payload_count,
-  uint16_t physical_payload_hint) {
+  PayloadLength payload_count,
+  PayloadLength physical_payload_hint) {
   if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.reserve_record_normalized(
@@ -323,9 +325,9 @@ ErrorCode MasstreeStorage::insert_record_normalized(
 ErrorCode MasstreeStorage::delete_record(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length) {
+  KeyLength key_length) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record(
@@ -343,7 +345,7 @@ ErrorCode MasstreeStorage::delete_record_normalized(
   thread::Thread* context,
   KeySlice key) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record_normalized(
@@ -361,16 +363,16 @@ ErrorCode MasstreeStorage::delete_record_normalized(
 ErrorCode MasstreeStorage::upsert_record(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   const void* payload,
-  uint16_t payload_count,
-  uint16_t physical_payload_hint) {
+  PayloadLength payload_count,
+  PayloadLength physical_payload_hint) {
   if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.reserve_record(
@@ -397,14 +399,14 @@ ErrorCode MasstreeStorage::upsert_record_normalized(
   thread::Thread* context,
   KeySlice key,
   const void* payload,
-  uint16_t payload_count,
-  uint16_t physical_payload_hint) {
+  PayloadLength payload_count,
+  PayloadLength physical_payload_hint) {
   if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.reserve_record_normalized(
@@ -430,12 +432,12 @@ ErrorCode MasstreeStorage::upsert_record_normalized(
 ErrorCode MasstreeStorage::overwrite_record(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   const void* payload,
-  uint16_t payload_offset,
-  uint16_t payload_count) {
+  PayloadLength payload_offset,
+  PayloadLength payload_count) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record(
@@ -462,11 +464,11 @@ template <typename PAYLOAD>
 ErrorCode MasstreeStorage::overwrite_record_primitive(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   PAYLOAD payload,
-  uint16_t payload_offset) {
+  PayloadLength payload_offset) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record(
@@ -493,10 +495,10 @@ ErrorCode MasstreeStorage::overwrite_record_normalized(
   thread::Thread* context,
   KeySlice key,
   const void* payload,
-  uint16_t payload_offset,
-  uint16_t payload_count) {
+  PayloadLength payload_offset,
+  PayloadLength payload_count) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record_normalized(
@@ -524,9 +526,9 @@ ErrorCode MasstreeStorage::overwrite_record_primitive_normalized(
   thread::Thread* context,
   KeySlice key,
   PAYLOAD payload,
-  uint16_t payload_offset) {
+  PayloadLength payload_offset) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record_normalized(
@@ -553,11 +555,11 @@ template <typename PAYLOAD>
 ErrorCode MasstreeStorage::increment_record(
   thread::Thread* context,
   const void* key,
-  uint16_t key_length,
+  KeyLength key_length,
   PAYLOAD* value,
-  uint16_t payload_offset) {
+  PayloadLength payload_offset) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record(
@@ -584,9 +586,9 @@ ErrorCode MasstreeStorage::increment_record_normalized(
   thread::Thread* context,
   KeySlice key,
   PAYLOAD* value,
-  uint16_t payload_offset) {
+  PayloadLength payload_offset) {
   MasstreeBorderPage* border;
-  uint8_t index;
+  SlotIndex index;
   xct::XctId observed;
   MasstreeStoragePimpl pimpl(this);
   CHECK_ERROR_CODE(pimpl.locate_record_normalized(
@@ -656,31 +658,32 @@ SlotIndex MasstreeStorage::estimate_records_per_page(
 // Explicit instantiations for each payload type
 // @cond DOXYGEN_IGNORE
 #define EXPIN_1(x) template ErrorCode MasstreeStorage::get_record_primitive< x > \
-  (thread::Thread* context, const void* key, uint16_t key_length, x* payload, \
-    uint16_t payload_offset)
+  (thread::Thread* context, const void* key, KeyLength key_length, x* payload, \
+    PayloadLength payload_offset)
 INSTANTIATE_ALL_NUMERIC_TYPES(EXPIN_1);
 
 #define EXPIN_2(x) template ErrorCode \
   MasstreeStorage::get_record_primitive_normalized< x > \
-  (thread::Thread* context, KeySlice key, x* payload, uint16_t payload_offset)
+  (thread::Thread* context, KeySlice key, x* payload, PayloadLength payload_offset)
 INSTANTIATE_ALL_NUMERIC_TYPES(EXPIN_2);
 
 #define EXPIN_3(x) template ErrorCode MasstreeStorage::overwrite_record_primitive< x > \
-  (thread::Thread* context, const void* key, uint16_t key_length, x payload, \
-  uint16_t payload_offset)
+  (thread::Thread* context, const void* key, KeyLength key_length, x payload, \
+  PayloadLength payload_offset)
 INSTANTIATE_ALL_NUMERIC_TYPES(EXPIN_3);
 
 #define EXPIN_4(x) template ErrorCode \
   MasstreeStorage::overwrite_record_primitive_normalized< x > \
-  (thread::Thread* context, KeySlice key, x payload, uint16_t payload_offset)
+  (thread::Thread* context, KeySlice key, x payload, PayloadLength payload_offset)
 INSTANTIATE_ALL_NUMERIC_TYPES(EXPIN_4);
 
 #define EXPIN_5(x) template ErrorCode MasstreeStorage::increment_record< x > \
-  (thread::Thread* context, const void* key, uint16_t key_length, x* value, uint16_t payload_offset)
+  (thread::Thread* context, const void* key, KeyLength key_length, x* value, \
+  PayloadLength payload_offset)
 INSTANTIATE_ALL_NUMERIC_TYPES(EXPIN_5);
 
 #define EXPIN_6(x) template ErrorCode MasstreeStorage::increment_record_normalized< x > \
-  (thread::Thread* context, KeySlice key, x* value, uint16_t payload_offset)
+  (thread::Thread* context, KeySlice key, x* value, PayloadLength payload_offset)
 INSTANTIATE_ALL_NUMERIC_TYPES(EXPIN_6);
 // @endcond
 

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
@@ -638,6 +638,20 @@ ErrorStack MasstreeStorage::fatify_first_root(thread::Thread* context, uint32_t 
   return MasstreeStoragePimpl(this).fatify_first_root(context, desired_count);
 }
 
+SlotIndex MasstreeStorage::estimate_records_per_page(
+  uint8_t layer,
+  KeyLength key_length,
+  PayloadLength payload_length) {
+  PayloadLength aligned_payload = assorted::align8(payload_length);
+  KeyLength aligned_suffix = 0;
+  if (key_length > (layer + 1U) * sizeof(KeySlice)) {
+    aligned_suffix = assorted::align8(key_length - (layer + 1U) * sizeof(KeySlice));
+  }
+  SlotIndex ret = kBorderPageDataPartSize
+    / (aligned_suffix + aligned_payload + kBorderPageSlotSize);
+  ASSERT_ND(ret <= kBorderPageMaxSlots);
+  return ret;
+}
 
 // Explicit instantiations for each payload type
 // @cond DOXYGEN_IGNORE

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage.cpp
@@ -244,8 +244,8 @@ uint16_t adjust_payload_hint(uint16_t payload_count, uint16_t physical_payload_h
   if (physical_payload_hint < payload_count) {
     physical_payload_hint = payload_count;
   }
-  if (physical_payload_hint > MasstreeBorderPage::kMaxPayload) {
-    physical_payload_hint = MasstreeBorderPage::kMaxPayload;
+  if (physical_payload_hint > kMaxPayloadLength) {
+    physical_payload_hint = kMaxPayloadLength;
   }
   physical_payload_hint = assorted::align8(physical_payload_hint);
   return physical_payload_hint;
@@ -258,7 +258,7 @@ ErrorCode MasstreeStorage::insert_record(
   const void* payload,
   uint16_t payload_count,
   uint16_t physical_payload_hint) {
-  if (UNLIKELY(payload_count > MasstreeBorderPage::kMaxPayload)) {
+  if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);
@@ -292,7 +292,7 @@ ErrorCode MasstreeStorage::insert_record_normalized(
   const void* payload,
   uint16_t payload_count,
   uint16_t physical_payload_hint) {
-  if (UNLIKELY(payload_count > MasstreeBorderPage::kMaxPayload)) {
+  if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);
@@ -365,7 +365,7 @@ ErrorCode MasstreeStorage::upsert_record(
   const void* payload,
   uint16_t payload_count,
   uint16_t physical_payload_hint) {
-  if (UNLIKELY(payload_count > MasstreeBorderPage::kMaxPayload)) {
+  if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);
@@ -399,7 +399,7 @@ ErrorCode MasstreeStorage::upsert_record_normalized(
   const void* payload,
   uint16_t payload_count,
   uint16_t physical_payload_hint) {
-  if (UNLIKELY(payload_count > MasstreeBorderPage::kMaxPayload)) {
+  if (UNLIKELY(payload_count > kMaxPayloadLength)) {
     return kErrorCodeStrTooLongPayload;
   }
   physical_payload_hint = adjust_payload_hint(payload_count, physical_payload_hint);

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage_fatify.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage_fatify.cpp
@@ -153,12 +153,13 @@ ErrorStack split_a_child(
         return kRetOk;
       }
       // trigger doesn't matter. just make sure it doesn't cause no-record-split. so, use low_fence.
+      // also, specify disable_nrs
       KeySlice trigger = casted->get_low_fence();
       MasstreeBorderPage* after = casted;
-      xct::McsBlockIndex after_lock;
-      casted->split_foster(context, trigger, &after, &after_lock);
+      xct::McsLockScope after_lock;
+      casted->split_foster(context, trigger, true, &after, &after_lock);
       ASSERT_ND(after->is_locked());
-      context->mcs_release_lock(after->get_lock_address(), after_lock);
+      ASSERT_ND(after_lock.is_locked());
       ASSERT_ND(casted->is_moved());
     } else {
       MasstreeIntermediatePage* casted = reinterpret_cast<MasstreeIntermediatePage*>(original_page);

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage_peek.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage_peek.cpp
@@ -110,9 +110,9 @@ ErrorCode MasstreeStoragePimpl::peek_volatile_page_boundaries_next_layer(
   // however, make sure we don't hit something like segfault. check nulls etc.
   ASSERT_ND(border->within_fences(slice));
   uint8_t key_count = border->get_key_count();
-  uint8_t rec = MasstreeBorderPage::kMaxKeys;
+  SlotIndex rec = kBorderPageMaxSlots;
   border->prefetch_additional_if_needed(key_count);
-  for (uint8_t i = 0; i < key_count; ++i) {
+  for (SlotIndex i = 0; i < key_count; ++i) {
     KeySlice cur_slice = border->get_slice(i);
     if (LIKELY(cur_slice < slice)) {
       continue;

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
@@ -230,21 +230,11 @@ ErrorStack MasstreeStoragePimpl::verify_single_thread_border(
     CHECK_AND_ASSERT(!page->get_owner_id(i)->lock_.is_rangelocked());
     CHECK_AND_ASSERT(!page->get_owner_id(i)->xct_id_.is_being_written());
     CHECK_AND_ASSERT(page->get_owner_id(i)->xct_id_.get_epoch().is_valid());
-    if (i == 0) {
-      CHECK_AND_ASSERT(page->get_offset_in_bytes(i) < MasstreeBorderPage::kDataSize);
-      CHECK_AND_ASSERT(page->get_offset_in_bytes(i) + page->get_physical_record_size_in_bytes(i)
-        == MasstreeBorderPage::kDataSize);
-    } else {
-      CHECK_AND_ASSERT(page->get_offset_in_bytes(i) < page->get_offset_in_bytes(i - 1));
-      CHECK_AND_ASSERT(page->get_offset_in_bytes(i) + page->get_physical_record_size_in_bytes(i)
-        == page->get_offset_in_bytes(i - 1));
-    }
+    CHECK_AND_ASSERT(page->verify_slot_lengthes(i));
     KeySlice slice = page->get_slice(i);
     CHECK_AND_ASSERT(slice >= low_fence);
     CHECK_AND_ASSERT(slice < high_fence.slice_ || page->is_high_fence_supremum());
     if (page->does_point_to_layer(i)) {
-      CHECK_AND_ASSERT(page->get_physical_record_size_in_bytes(i)
-        >= sizeof(DualPagePointer));
       CHECK_AND_ASSERT(page->get_owner_id(i)->xct_id_.is_next_layer());
       CHECK_AND_ASSERT(!page->get_next_layer(i)->is_both_null());
       MasstreePage* next;
@@ -254,9 +244,6 @@ ErrorStack MasstreeStoragePimpl::verify_single_thread_border(
       CHECK_ERROR(verify_single_thread_layer(context, page->get_layer() + 1, next));
     } else {
       CHECK_AND_ASSERT(!page->get_owner_id(i)->xct_id_.is_next_layer());
-      CHECK_AND_ASSERT(page->get_physical_record_size_in_bytes(i)
-        >= page->get_suffix_length_aligned(i) + page->get_payload_length(i));
-      CHECK_AND_ASSERT(page->get_max_payload_length(i) >= page->get_payload_length(i));
     }
   }
 

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
@@ -197,11 +197,11 @@ ErrorStack MasstreeStoragePimpl::verify_single_thread_border(
   CHECK_ERROR(verify_page_basic(context, page, kMasstreeBorderPageType, low_fence, high_fence));
   // check consecutive_inserts_. this should be consistent whether it's moved or not.
   bool sorted = true;
-  for (uint8_t i = 1; i < page->get_key_count(); ++i) {
+  for (SlotIndex i = 1; i < page->get_key_count(); ++i) {
     KeySlice prev = page->get_slice(i - 1);
     KeySlice slice = page->get_slice(i);
-    uint8_t prev_len = page->get_remaining_key_length(i - 1);
-    uint8_t len = page->get_remaining_key_length(i);
+    KeyLength prev_len = page->get_remainder_length(i - 1);
+    KeyLength len = page->get_remainder_length(i);
     if (prev > slice || (prev == slice && prev_len > len)) {
       sorted = false;
       break;

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
@@ -224,8 +224,8 @@ ErrorStack MasstreeStoragePimpl::verify_single_thread_border(
   }
 
   CHECK_AND_ASSERT(!page->is_moved());
-  CHECK_AND_ASSERT(page->get_key_count() <= MasstreeBorderPage::kMaxKeys);
-  for (uint8_t i = 0; i < page->get_key_count(); ++i) {
+  CHECK_AND_ASSERT(page->get_key_count() <= kBorderPageMaxSlots);
+  for (SlotIndex i = 0; i < page->get_key_count(); ++i) {
     CHECK_AND_ASSERT(!page->get_owner_id(i)->lock_.is_keylocked());
     CHECK_AND_ASSERT(!page->get_owner_id(i)->lock_.is_rangelocked());
     CHECK_AND_ASSERT(!page->get_owner_id(i)->xct_id_.is_being_written());

--- a/foedus-core/src/foedus/storage/page.cpp
+++ b/foedus-core/src/foedus/storage/page.cpp
@@ -88,6 +88,17 @@ PageVersionLockScope::PageVersionLockScope(
   }
 }
 
+PageVersionLockScope::PageVersionLockScope(xct::McsLockScope* move_from) {
+  ASSERT_ND(move_from->is_locked());
+  context_ = nullptr;
+  version_ = nullptr;
+  changed_ = false;
+  released_ = false;
+  move_from->move_to(this);
+  ASSERT_ND(!move_from->is_locked());
+}
+
+
 void PageVersionLockScope::release() {
   if (!released_) {
     if (changed_) {

--- a/foedus-core/src/foedus/xct/xct_id.cpp
+++ b/foedus-core/src/foedus/xct/xct_id.cpp
@@ -158,6 +158,7 @@ std::ostream& operator<<(std::ostream& o, const XctId& v) {
       << (v.is_deleted() ? "D" : " ")
       << (v.is_moved() ? "M" : " ")
       << (v.is_being_written() ? "W" : " ")
+      << (v.is_next_layer() ? "N" : " ")
     << "\" />";
   return o;
 }

--- a/tests-core/src/foedus/storage/masstree/CMakeLists.txt
+++ b/tests-core/src/foedus/storage/masstree/CMakeLists.txt
@@ -7,8 +7,10 @@ set(test_masstree_basic_individuals
   NextLayer
   CreateAndDrop
   ExpandInsert
+  ExpandInsertNextLayer
   ExpandInsertNormalized
   ExpandUpdate
+  ExpandUpdateNextLayer
   ExpandUpdateNormalized
   )
 add_foedus_test_individual(test_masstree_basic "${test_masstree_basic_individuals}")

--- a/tests-core/src/foedus/storage/masstree/CMakeLists.txt
+++ b/tests-core/src/foedus/storage/masstree/CMakeLists.txt
@@ -23,7 +23,15 @@ add_foedus_test_individual(test_masstree_peek "OneLayer;TwoLayers")
 
 add_foedus_test_individual(test_masstree_random "InsertManyNormalized;InsertManyNormalizedMt;InsertMany")
 
-add_foedus_test_individual(test_masstree_split "SplitBorder;SplitBorderNormalized;SplitInNextLayer")
+set(test_masstree_split_individuals
+  SplitBorder
+  SplitBorderNormalized
+  SplitInNextLayer
+  SplitInNextLayerWithHint
+  SplitIntermediateSequential
+  SplitIntermediateSequentialWithHint
+  )
+add_foedus_test_individual(test_masstree_split "${test_masstree_split_individuals}")
 
 set(test_masstree_tpcb_individuals
   SingleThreadedNoContention
@@ -63,6 +71,21 @@ set(test_masstree_tpcc_individuals
   DistrictScanOrders
   DistrictScanOrdersSecondary
   DistrictScanOrderlines
+  FullscanCustomersSecondaryWithHint
+  FullscanNewordersWithHint
+  FullscanOrdersWithHint
+  FullscanOrdersSecondaryWithHint
+  FullscanOrderlinesWithHint
+  ParallelLoadCustomersSecondaryWithHint
+  ParallelLoadNewordersWithHint
+  ParallelLoadOrdersWithHint
+  ParallelLoadOrdersSecondaryWithHint
+  ParallelLoadOrderlinesWithHint
+  DistrictScanCustomersSecondaryWithHint
+  DistrictScanNewordersWithHint
+  DistrictScanOrdersWithHint
+  DistrictScanOrdersSecondaryWithHint
+  DistrictScanOrderlinesWithHint
   )
 add_foedus_test_individual(test_masstree_tpcc "${test_masstree_tpcc_individuals}")
 

--- a/tests-core/src/foedus/storage/masstree/test_masstree_basic.cpp
+++ b/tests-core/src/foedus/storage/masstree/test_masstree_basic.cpp
@@ -308,6 +308,7 @@ TEST(MasstreeBasicTest, CreateAndDrop) {
 struct ExpandTaskInput {
   bool update_case_;
   bool normalized_case_;
+  bool next_layer_case_;
 };
 
 ErrorStack expand_task(const proc::ProcArguments& args) {
@@ -318,93 +319,118 @@ ErrorStack expand_task(const proc::ProcArguments& args) {
   xct::XctManager* xct_manager = context->get_engine()->get_xct_manager();
   Epoch commit_epoch;
 
-  const KeySlice kKeyNormalized = normalize_primitive<uint64_t>(12345ULL);
-  const std::string kKey("key1234567890");
+  // Use two keys and expand in-turn so that we quickly use up the space in the page.
+  // If we have only one-key, the new page layout allows just expanding the only record,
+  // thus we don't cause any page-split (which is good, but we want to test tricky cases).
+  const KeySlice kKeyNormalized[2] = {
+    normalize_primitive<uint64_t>(12345ULL),
+    normalize_primitive<uint64_t>(12346ULL),
+  };
+  std::string kKey[2];
+  if (inputs->next_layer_case_) {
+    // Differ only in next layer. We have a single record in first layer
+    kKey[0] = std::string("key1234567890");
+    kKey[1] = std::string("key1234567891");
+  } else {
+    // Uses only one layer
+    kKey[0] = std::string("key1234567890");
+    kKey[1] = std::string("key1235abcdef");
+  }
+  EXPECT_EQ(kKey[0].size(), kKey[1].size());
+  KeyLength kKeyLen = kKey[0].size();
   char data[512];
-  for (uint16_t c = 0; c < sizeof(data); ++c) {
+  for (PayloadLength c = 0; c < sizeof(data); ++c) {
     data[c] = static_cast<char>(c);
   }
 
-  const uint16_t kInitialLen = 6;
-  const uint16_t kExpandLen = 5;
+  const PayloadLength kInitialLen = 6;
+  const PayloadLength kExpandLen = 5;
   const uint16_t kRep = 80;
   ASSERT_ND(kInitialLen + kExpandLen * kRep <= sizeof(data));
 
   CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
-  if (inputs->normalized_case_) {
-    CHECK_ERROR(storage.insert_record_normalized(context, kKeyNormalized, data, kInitialLen));
-  } else {
-    CHECK_ERROR(storage.insert_record(context, kKey.data(), kKey.size(), data, kInitialLen));
+  for (int i = 0; i < 2; ++i) {
+    if (inputs->normalized_case_) {
+      CHECK_ERROR(storage.insert_record_normalized(context, kKeyNormalized[i], data, kInitialLen));
+    } else {
+      CHECK_ERROR(storage.insert_record(context, kKey[i].data(), kKeyLen, data, kInitialLen));
+    }
   }
   CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
 
   CHECK_ERROR(storage.verify_single_thread(context));
 
   // expand the record many times. this will create a few pages.
-  uint16_t len = kInitialLen;
+  PayloadLength len = kInitialLen;
   for (uint16_t rep = 0; rep < kRep; ++rep) {
     len += kExpandLen;
-    if (!inputs->update_case_) {
-      // in this case we move a deleted record, using insert
-      CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
-      if (inputs->normalized_case_) {
-        CHECK_ERROR(storage.delete_record_normalized(context, kKeyNormalized));
+    for (int i = 0; i < 2; ++i) {
+      KeySlice norm_key = kKeyNormalized[i];
+      const char* key = kKey[i].data();
+      if (!inputs->update_case_) {
+        // in this case we move a deleted record, using insert
+        CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
+        if (inputs->normalized_case_) {
+          CHECK_ERROR(storage.delete_record_normalized(context, norm_key));
+        } else {
+          CHECK_ERROR(storage.delete_record(context, key, kKeyLen));
+        }
+        CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
+        CHECK_ERROR(storage.verify_single_thread(context));
+
+        CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
+        if (inputs->normalized_case_) {
+          CHECK_ERROR(storage.insert_record_normalized(context, norm_key, data, len));
+        } else {
+          CHECK_ERROR(storage.insert_record(context, key, kKeyLen, data, len));
+        }
+        CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
       } else {
-        CHECK_ERROR(storage.delete_record(context, kKey.data(), kKey.size()));
+        // in this case we move an active record, using upsert
+        CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
+        if (inputs->normalized_case_) {
+          CHECK_ERROR(storage.upsert_record_normalized(context, norm_key, data, len));
+        } else {
+          CHECK_ERROR(storage.upsert_record(context, key, kKeyLen, data, len));
+        }
+        CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
       }
-      CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
+
       CHECK_ERROR(storage.verify_single_thread(context));
-
-      CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
-      if (inputs->normalized_case_) {
-        CHECK_ERROR(storage.insert_record_normalized(context, kKeyNormalized, data, len));
-      } else {
-        CHECK_ERROR(storage.insert_record(context, kKey.data(), kKey.size(), data, len));
-      }
-      CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
-    } else {
-      // in this case we move an active record, using upsert
-      CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
-      if (inputs->normalized_case_) {
-        CHECK_ERROR(storage.upsert_record_normalized(context, kKeyNormalized, data, len));
-      } else {
-        CHECK_ERROR(storage.upsert_record(context, kKey.data(), kKey.size(), data, len));
-      }
-      CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
     }
-
-    CHECK_ERROR(storage.verify_single_thread(context));
   }
 
   // verify that the record exists
   CHECK_ERROR(storage.verify_single_thread(context));
 
-  CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
-  char retrieved[sizeof(data)];
-  std::memset(retrieved, 42, sizeof(retrieved));
-  uint16_t retrieved_capacity = sizeof(retrieved);
-  if (inputs->normalized_case_) {
-    CHECK_ERROR(storage.get_record_normalized(
-      context,
-      kKeyNormalized,
-      retrieved,
-      &retrieved_capacity));
-  } else {
-    CHECK_ERROR(storage.get_record(
-      context,
-      kKey.data(),
-      kKey.size(),
-      retrieved,
-      &retrieved_capacity));
-  }
-  CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
+  for (int i = 0; i < 2; ++i) {
+    CHECK_ERROR(xct_manager->begin_xct(context, xct::kSerializable));
+    char retrieved[sizeof(data)];
+    std::memset(retrieved, 42, sizeof(retrieved));
+    PayloadLength retrieved_capacity = sizeof(retrieved);
+    if (inputs->normalized_case_) {
+      CHECK_ERROR(storage.get_record_normalized(
+        context,
+        kKeyNormalized[i],
+        retrieved,
+        &retrieved_capacity));
+    } else {
+      CHECK_ERROR(storage.get_record(
+        context,
+        kKey[i].data(),
+        kKeyLen,
+        retrieved,
+        &retrieved_capacity));
+    }
+    CHECK_ERROR(xct_manager->precommit_xct(context, &commit_epoch));
 
-  EXPECT_EQ(kInitialLen + kRep * kExpandLen, retrieved_capacity);
-  for (uint16_t c = 0; c < retrieved_capacity; ++c) {
-    EXPECT_EQ(static_cast<char>(c), retrieved[c]) << c;
-  }
-  for (uint16_t c = retrieved_capacity; c < sizeof(retrieved); ++c) {
-    EXPECT_EQ(42, retrieved[c]) << c;
+    EXPECT_EQ(kInitialLen + kRep * kExpandLen, retrieved_capacity);
+    for (PayloadLength c = 0; c < retrieved_capacity; ++c) {
+      EXPECT_EQ(static_cast<char>(c), retrieved[c]) << c;
+    }
+    for (PayloadLength c = retrieved_capacity; c < sizeof(retrieved); ++c) {
+      EXPECT_EQ(42, retrieved[c]) << c;
+    }
   }
 
   CHECK_ERROR(storage.verify_single_thread(context));
@@ -414,7 +440,7 @@ ErrorStack expand_task(const proc::ProcArguments& args) {
   return foedus::kRetOk;
 }
 
-void test_expand(bool update_case, bool normalized) {
+void test_expand(bool update_case, bool normalized, bool next_layer) {
   EngineOptions options = get_tiny_options();
   Engine engine(options);
   engine.get_proc_manager()->pre_register("expand_task", expand_task);
@@ -426,7 +452,7 @@ void test_expand(bool update_case, bool normalized) {
     Epoch epoch;
     COERCE_ERROR(engine.get_storage_manager()->create_masstree(&meta, &storage, &epoch));
     EXPECT_TRUE(storage.exists());
-    ExpandTaskInput inputs = { update_case, normalized };
+    ExpandTaskInput inputs = { update_case, normalized, next_layer };
     COERCE_ERROR(engine.get_thread_pool()->impersonate_synchronous(
       "expand_task",
       &inputs,
@@ -436,10 +462,12 @@ void test_expand(bool update_case, bool normalized) {
   cleanup_test(options);
 }
 
-TEST(MasstreeBasicTest, ExpandInsert) { test_expand(false, false); }
-TEST(MasstreeBasicTest, ExpandInsertNormalized) { test_expand(false, true); }
-TEST(MasstreeBasicTest, ExpandUpdate) { test_expand(true, false); }
-TEST(MasstreeBasicTest, ExpandUpdateNormalized) { test_expand(true, true); }
+TEST(MasstreeBasicTest, ExpandInsert) { test_expand(false, false, false); }
+TEST(MasstreeBasicTest, ExpandInsertNextLayer) { test_expand(false, false, true); }
+TEST(MasstreeBasicTest, ExpandInsertNormalized) { test_expand(false, true, false); }
+TEST(MasstreeBasicTest, ExpandUpdate) { test_expand(true, false, false); }
+TEST(MasstreeBasicTest, ExpandUpdateNextLayer) { test_expand(true, false, true); }
+TEST(MasstreeBasicTest, ExpandUpdateNormalized) { test_expand(true, true, false); }
 // TASK(Hideaki): we don't have multi-thread cases here. it's not a "basic" test.
 // no multi-key cases either.
 

--- a/tests-core/src/foedus/storage/masstree/test_masstree_split.cpp
+++ b/tests-core/src/foedus/storage/masstree/test_masstree_split.cpp
@@ -198,7 +198,7 @@ ErrorStack split_in_next_layer_task(const proc::ProcArguments& args) {
   return foedus::kRetOk;
 }
 
-TEST(MasstreeSplitTest, SplitInNextLayer) {
+void test_split_in_next_layer(bool with_hint) {
   EngineOptions options = get_tiny_options();
   Engine engine(options);
   engine.get_proc_manager()->pre_register("split_in_next_layer_task", split_in_next_layer_task);
@@ -206,6 +206,9 @@ TEST(MasstreeSplitTest, SplitInNextLayer) {
   {
     UninitializeGuard guard(&engine);
     MasstreeMetadata meta("ggg");
+    if (with_hint) {
+      meta.min_layer_hint_ = 1U;
+    }
     MasstreeStorage storage;
     Epoch epoch;
     COERCE_ERROR(engine.get_storage_manager()->create_masstree(&meta, &storage, &epoch));
@@ -215,6 +218,9 @@ TEST(MasstreeSplitTest, SplitInNextLayer) {
   }
   cleanup_test(options);
 }
+
+TEST(MasstreeSplitTest, SplitInNextLayer)         { test_split_in_next_layer(false); }
+TEST(MasstreeSplitTest, SplitInNextLayerWithHint) { test_split_in_next_layer(true); }
 
 ErrorStack split_intermediate_sequential_task(const proc::ProcArguments& args) {
   thread::Thread* context = args.context_;
@@ -263,7 +269,7 @@ ErrorStack split_intermediate_sequential_task(const proc::ProcArguments& args) {
   return foedus::kRetOk;
 }
 
-TEST(MasstreeSplitTest, SplitIntermediateSequential) {
+void test_split_intermediate_sequential(bool with_hint) {
   EngineOptions options = get_tiny_options();
   Engine engine(options);
   engine.get_proc_manager()->pre_register("the_task", split_intermediate_sequential_task);
@@ -271,6 +277,9 @@ TEST(MasstreeSplitTest, SplitIntermediateSequential) {
   {
     UninitializeGuard guard(&engine);
     MasstreeMetadata meta("ggg");
+    if (with_hint) {
+      meta.min_layer_hint_ = 1U;
+    }
     MasstreeStorage storage;
     Epoch epoch;
     COERCE_ERROR(engine.get_storage_manager()->create_masstree(&meta, &storage, &epoch));
@@ -279,6 +288,10 @@ TEST(MasstreeSplitTest, SplitIntermediateSequential) {
     COERCE_ERROR(engine.uninitialize());
   }
   cleanup_test(options);
+}
+TEST(MasstreeSplitTest, SplitIntermediateSequential) { test_split_intermediate_sequential(false); }
+TEST(MasstreeSplitTest, SplitIntermediateSequentialWithHint) {
+  test_split_intermediate_sequential(true);
 }
 
 }  // namespace masstree


### PR DESCRIPTION
Overhauls the page layout in masstree package.

 * Now Slot is placed at the end of data region rather than statically and contiguously placing LocableXctId. This saves space and also reduces cacheline contention (each Slot is 32 bytes as opposed to 16 bytes LocableXctId).
 * Suffix key is always untouched after expansion or next-layer move, which simplifies concurrency control and also allows tracking moved records into next layer in all situations.
 * A hint option to start with next-layer records in higher layers.
 * Completely changed how we expand records. Now we can expand records in-page much more efficiently.
 * Now page-split is dumb simple, copying a record one-by-one. This comes with a cost of many more memcpy. Hopefully most beneficial cases are still captured by no-record-split (which still uses just 2 memcpy). Instead page-split removes wasted spaces more aggressively than previous.
 * The same record-expand trick should be also used in hash package, later, later..

This is a huge change. Although all testcases pass, we should also run performance regression tests.
Will do it before merging to master.