### PR TITLE
test_direct_io testcase was conflicting with concurrent runs. now pre…

### DIFF
--- a/foedus-core/src/foedus/memory/aligned_memory.cpp
+++ b/foedus-core/src/foedus/memory/aligned_memory.cpp
@@ -93,7 +93,7 @@ char* alloc_mmap(uint64_t size, uint64_t alignment) {
     0));
   // Note: We previously used MAP_NORESERVE to explicitly say we don't want swapping,
   // but mmap with this flag causes SIGSEGV when there aren't enough hugepages.
-  // In that case mmap doesn't return -1 because it just checks VA space is mappable.
+  // In that case mmap doesn't return -1 because it just checks if VA space is mappable.
   // We still don't need swapping, but it won't hurt. sorta. Debuggability matters more.
 
   // when mmap() fails, it returns -1 (MAP_FAILED)

--- a/tests-core/src/foedus/fs/test_direct_io_file.cpp
+++ b/tests-core/src/foedus/fs/test_direct_io_file.cpp
@@ -50,9 +50,7 @@ void test_tmpfs(std::string root) {
   // this is mainly testing the O_DIRECT error on tmpfs
   // http://www.gossamer-threads.com/lists/linux/kernel/720702
   Path folder_path(root + "/foedus_test");
-  if (exists(folder_path)) {
-    remove_all(folder_path);
-  }
+  folder_path /= get_random_name();
   EXPECT_FALSE(exists(folder_path));
   EXPECT_TRUE(fs::create_directories(folder_path));
 


### PR DESCRIPTION
…pend a random name.