### PR TITLE
Major: Expanded McsLock to be 8-bytes for the planned work on locking.

### DIFF
--- a/foedus-core/include/foedus/storage/array/array_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/array/array_page_impl.hpp
@@ -113,29 +113,26 @@ class ArrayPage final {
 
   uint8_t                 unused_dummy_func_reserved1() const { return reserved1_; }
   uint32_t                unused_dummy_func_reserved2() const { return reserved2_; }
-  uint64_t                unused_dummy_func_dummy() const { return dummy_; }
 
  private:
   /** common header */
-  PageHeader          header_;        // +32 -> 32
+  PageHeader          header_;        // +40 -> 40
 
   /** Byte size of one record in this array storage without internal overheads. */
-  uint16_t            payload_size_;  // +2 -> 34
+  uint16_t            payload_size_;  // +2 -> 42
 
   /** Height of this node, counting up from 0 (leaf). */
-  uint8_t             level_;         // +1 -> 35
+  uint8_t             level_;         // +1 -> 43
 
-  uint8_t             reserved1_;     // +1 -> 36
-  uint32_t            reserved2_;     // +4 -> 40
+  uint8_t             reserved1_;     // +1 -> 44
+  uint32_t            reserved2_;     // +4 -> 48
 
   /**
    * The offset range this node is in charge of. Mainly for sanity checking.
    * If this page is right-most (eg root page), the end is the array's size,
    * which might be smaller than the range it can physically contain.
    */
-  ArrayRange          array_range_;   // +16 -> 56
-
-  uint64_t            dummy_;         // +8 -> 64
+  ArrayRange          array_range_;   // +16 -> 64
 
   // All variables up to here are immutable after the array storage is created.
 

--- a/foedus-core/include/foedus/storage/hash/hash_composed_bins_impl.hpp
+++ b/foedus-core/include/foedus/storage/hash/hash_composed_bins_impl.hpp
@@ -87,7 +87,7 @@ struct ComposedBin final {
   SnapshotPagePointer page_id_;
 };
 
-const uint16_t kHashComposedBinsPageMaxBins = (kPageSize - 64) / sizeof(ComposedBin);
+const uint16_t kHashComposedBinsPageMaxBins = (kPageSize - 80) / sizeof(ComposedBin);
 
 /**
  * @brief A page to pack many ComposedBin as an output of composer.
@@ -99,11 +99,12 @@ const uint16_t kHashComposedBinsPageMaxBins = (kPageSize - 64) / sizeof(Composed
  * All bins stored here are sorted by bin.
  */
 struct HashComposedBinsPage final {
-  PageHeader          header_;      // +32 -> 32
-  HashBinRange        bin_range_;   // +16 -> 48
-  SnapshotPagePointer next_page_;   // +8  -> 56
-  uint32_t            bin_count_;   // +4  -> 60
-  uint32_t            dummy_;       // +4  -> 64
+  PageHeader          header_;      // +40 -> 40
+  HashBinRange        bin_range_;   // +16 -> 56
+  SnapshotPagePointer next_page_;   // +8  -> 64
+  uint32_t            bin_count_;   // +4  -> 68
+  uint32_t            dummy_;       // +4  -> 72
+  uint64_t            padding_;     // +8  -> 80
   ComposedBin         bins_[kHashComposedBinsPageMaxBins];    // -> 4096
 };
 

--- a/foedus-core/include/foedus/storage/hash/hash_id.hpp
+++ b/foedus-core/include/foedus/storage/hash/hash_id.hpp
@@ -37,7 +37,7 @@ namespace hash {
  * @brief Byte size of header in an intermediate page of hash storage.
  * @ingroup HASH
  */
-const uint16_t kHashIntermediatePageHeaderSize  = 48;
+const uint16_t kHashIntermediatePageHeaderSize  = 64;
 
 /**
  * @brief Number of pointers in an intermediate page of hash storage.

--- a/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_id.hpp
@@ -141,7 +141,7 @@ const KeySlice kSupremumSlice = 0xFFFFFFFFFFFFFFFFULL;
  * intermediate and border pages placed at the beginning.
  * @ingroup MASSTREE
  */
-const uint32_t kCommonPageHeaderSize = 72U;
+const uint32_t kCommonPageHeaderSize = 80U;
 
 /**
  * Misc header attributes specific to MasstreeBorderPage placed after the common header.
@@ -174,7 +174,11 @@ const uint32_t kBorderPageDataPartSize
     - kBorderPageMaxSlots * sizeof(KeySlice);
 
 /** Offset of data_ member in MasstreeBorderPage */
-const DataOffset kBorderPageDataPartOffset = 880;
+const DataOffset kBorderPageDataPartOffset
+  = kCommonPageHeaderSize
+  + 8U  // next_offset_, consecutive_inserts_, dummy_
+  + kBorderPageMaxSlots * sizeof(KeySlice);  // slices_
+
 /**
  * @brief Order-preserving normalization for primitive key types.
  * @param[in] value the value to normalize

--- a/foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp
@@ -1047,7 +1047,7 @@ class MasstreeBorderPage final : public MasstreePage {
    */
   bool        consecutive_inserts_;         // +1 -> 83
 
-  /** To make the following part a multiply of 16-bytes. */
+  /** To make the following part a multiply of 8-bytes. */
   char        dummy_[5];                    // +5 -> 88
 
   /**

--- a/foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp
@@ -167,14 +167,14 @@ class MasstreePage {
   friend std::ostream& operator<<(std::ostream& o, const MasstreePage& v);
 
  protected:
-  PageHeader          header_;      // +32 -> 32
+  PageHeader          header_;      // +40 -> 40
 
   /** Inclusive low fence of this page. Mainly used for sanity checking */
-  KeySlice            low_fence_;   // +8 -> 40
+  KeySlice            low_fence_;   // +8 -> 48
   /** Inclusive high fence of this page. Mainly used for sanity checking */
-  KeySlice            high_fence_;  // +8 -> 48
+  KeySlice            high_fence_;  // +8 -> 56
   /** Inclusive low_fence of foster child. undefined if foster child is not set*/
-  KeySlice            foster_fence_;  // +8 -> 56
+  KeySlice            foster_fence_;  // +8 -> 64
 
   /**
    * Points to foster children, or tentative child pages.
@@ -184,7 +184,7 @@ class MasstreePage {
    * [0]: Left-half of this page, or minor foster child.
    * [1]: Right-half of this page, or major foster child.
    */
-  VolatilePagePointer foster_twin_[2];  // +16 -> 72
+  VolatilePagePointer foster_twin_[2];  // +16 -> 80
 
   void                initialize_volatile_common(
     StorageId           storage_id,
@@ -428,7 +428,7 @@ class MasstreeIntermediatePage final : public MasstreePage {
   friend std::ostream& operator<<(std::ostream& o, const MasstreeIntermediatePage& v);
 
  private:
-  // 72
+  // 80
 
   /**
    * Separators to navigate search to mini pages in this page.
@@ -436,9 +436,9 @@ class MasstreeIntermediatePage final : public MasstreePage {
    * Iff Slice < separators_[0] or key_count==0, mini_pages_[0].
    * Iff Slice >= separators_[key_count-1] or key_count==0, mini_pages_[key_count].
    */
-  KeySlice            separators_[kMaxIntermediateSeparators];  // +72 -> 144
+  KeySlice            separators_[kMaxIntermediateSeparators];  // +72 -> 152
 
-  char                reserved_[112];    // -> 256
+  char                reserved_[104];    // -> 256
 
   MiniPage            mini_pages_[10];  // +384 * 10 -> 4096
 
@@ -1032,23 +1032,23 @@ class MasstreeBorderPage final : public MasstreePage {
   friend std::ostream& operator<<(std::ostream& o, const MasstreeBorderPage& v);
 
  private:
-  // 72
+  // 80
   /**
    * How many bytes this page has consumed from the beginning of data_.
    * In other words, the offset of a next new record.
    * @invariant next_offset_ % 8 == 0
    * @invariant next_offset_ + get_key_count() * sizeof(Slot) <= kBorderPageDataSize
    */
-  DataOffset  next_offset_;                 // +2 -> 74
+  DataOffset  next_offset_;                 // +2 -> 82
   /**
    * Whether this page is receiving only sequential inserts.
    * If this is true, cursor can skip its sorting phase.
    * If this is a snapshot page, this is always true.
    */
-  bool        consecutive_inserts_;         // +1 -> 75
+  bool        consecutive_inserts_;         // +1 -> 83
 
   /** To make the following part a multiply of 16-bytes. */
-  char        dummy_[5];                    // +5 -> 80
+  char        dummy_[5];                    // +5 -> 88
 
   /**
    * Key slice of this page. Unlike other information in the slots and records,

--- a/foedus-core/include/foedus/storage/sequential/sequential_id.hpp
+++ b/foedus-core/include/foedus/storage/sequential/sequential_id.hpp
@@ -40,7 +40,7 @@ const uint16_t kMaxSlots = 1 << 15;
  * Byte size of header in each data page of sequential storage.
  * @ingroup SEQUENTIAL
  */
-const uint16_t kHeaderSize = 56;
+const uint16_t kHeaderSize = 64;
 /**
  * Byte size of data region in each data page of sequential storage.
  * @ingroup SEQUENTIAL
@@ -57,7 +57,7 @@ const uint16_t kMaxPayload = kDataSize;
  * Byte size of header in each root page of sequential storage.
  * @ingroup SEQUENTIAL
  */
-const uint16_t kRootPageHeaderSize = 48;
+const uint16_t kRootPageHeaderSize = 56;
 
 /**
  * Each pointer to a snapshot head page comes with a bit more information to help reading.

--- a/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
+++ b/foedus-core/include/foedus/storage/sequential/sequential_page_impl.hpp
@@ -209,17 +209,17 @@ class SequentialPage final {
   /** Byte length of payload is represented in 2 bytes. */
   typedef uint16_t PayloadLength;
 
-  PageHeader            header_;            // +32 -> 32
+  PageHeader            header_;            // +40 -> 40
 
-  uint16_t              record_count_;      // +2 -> 34
-  uint16_t              used_data_bytes_;   // +2 -> 36
-  uint32_t              filler_;            // +4 -> 40
+  uint16_t              record_count_;      // +2 -> 42
+  uint16_t              used_data_bytes_;   // +2 -> 44
+  uint32_t              filler_;            // +4 -> 48
 
   /**
    * Pointer to next page.
    * Once it is set, the pointer and the pointed page will never be changed.
    */
-  DualPagePointer       next_page_;         // +16 -> 56
+  DualPagePointer       next_page_;         // +16 -> 64
 
   /**
    * Dynamic data part in this page, which consist of 1) record part growing forward,
@@ -281,16 +281,16 @@ class SequentialRootPage final {
   const char*         unused_dummy_func_filler() const { return filler_; }
 
  private:
-  PageHeader          header_;          // +32 -> 32
+  PageHeader          header_;          // +40 -> 40
 
   /**
    * How many pointers to head pages exist in this page.
    * 64bit is too much, but we don't need any other info in this page. Kind of a filler, too.
    */
-  uint64_t            pointer_count_;   // +8 -> 40
+  uint64_t            pointer_count_;   // +8 -> 48
 
   /** Pointer to next root page. */
-  SnapshotPagePointer next_page_;       // +8 -> 48
+  SnapshotPagePointer next_page_;       // +8 -> 56
 
   /** Pointers to heads of data pages. */
   HeadPagePointer     head_page_pointers_[kRootPageMaxHeadPointers];

--- a/foedus-core/include/foedus/xct/fwd.hpp
+++ b/foedus-core/include/foedus/xct/fwd.hpp
@@ -24,7 +24,6 @@
  */
 namespace foedus {
 namespace xct {
-class   CombinedLock;
 struct  InCommitEpochGuard;
 struct  LockableXctId;
 struct  LockFreeWriteXctAccess;

--- a/foedus-core/src/foedus/storage/array/array_storage_pimpl.cpp
+++ b/foedus-core/src/foedus/storage/array/array_storage_pimpl.cpp
@@ -982,9 +982,8 @@ ErrorStack ArrayStoragePimpl::verify_single_thread(thread::Thread* context, Arra
       CHECK_AND_ASSERT(!record->owner_id_.is_deleted());
       CHECK_AND_ASSERT(!record->owner_id_.is_keylocked());
       CHECK_AND_ASSERT(!record->owner_id_.is_moved());
-      CHECK_AND_ASSERT(record->owner_id_.lock_.get_version() == 0);
-      CHECK_AND_ASSERT(record->owner_id_.lock_.get_key_lock()->get_tail_waiter() == 0);
-      CHECK_AND_ASSERT(record->owner_id_.lock_.get_key_lock()->get_tail_waiter_block() == 0);
+      CHECK_AND_ASSERT(record->owner_id_.lock_.get_tail_waiter() == 0);
+      CHECK_AND_ASSERT(record->owner_id_.lock_.get_tail_waiter_block() == 0);
     }
   } else {
     for (uint16_t i = 0; i < kInteriorFanout; ++i) {

--- a/foedus-core/src/foedus/storage/hash/hash_page_debug.cpp
+++ b/foedus-core/src/foedus/storage/hash/hash_page_debug.cpp
@@ -87,7 +87,7 @@ std::ostream& operator<<(std::ostream& o, const HashDataPage& v) {
 
 
 void HashDataPage::assert_entries_impl() const {
-  ASSERT_ND(bin_bits_ + bin_shifts_ == 64U);
+  const uint8_t bin_shifts = get_bin_shifts();
   uint8_t records = get_record_count();
 
   if (header_.snapshot_) {
@@ -106,7 +106,7 @@ void HashDataPage::assert_entries_impl() const {
     }
     HashValue hash = hashinate(record_from_offset(slot->offset_), slot->key_length_);
     ASSERT_ND(slot->hash_ == hash);
-    HashBin bin = hash >> bin_shifts_;
+    HashBin bin = hash >> bin_shifts;
     ASSERT_ND(bin_ == bin);
 
     correct_filter.add(DataPageBloomFilter::extract_fingerprint(slot->hash_));

--- a/foedus-core/src/foedus/storage/hash/hash_page_impl.cpp
+++ b/foedus-core/src/foedus/storage/hash/hash_page_impl.cpp
@@ -74,11 +74,11 @@ void HashDataPage::initialize_volatile_page(
   HashBin bin,
   uint8_t bin_bits,
   uint8_t bin_shifts) {
+  ASSERT_ND(bin_bits + bin_shifts == 64U);
   std::memset(this, 0, kPageSize);
   header_.init_volatile(page_id, storage_id, kHashDataPageType);
   bin_ = bin;
-  bin_bits_ = bin_bits;
-  bin_shifts_ = bin_shifts;
+  protected_set_bin_shifts(bin_shifts);
   ASSERT_ND(parent);
   if (parent->get_header().get_page_type() == kHashIntermediatePageType) {
     const HashIntermediatePage* parent_casted
@@ -88,8 +88,7 @@ void HashDataPage::initialize_volatile_page(
   } else {
     const HashDataPage* parent_casted = reinterpret_cast<const HashDataPage*>(parent);
     ASSERT_ND(parent_casted->get_bin() == bin);
-    ASSERT_ND(parent_casted->bin_bits_ == bin_bits);
-    ASSERT_ND(parent_casted->bin_shifts_ == bin_shifts);
+    ASSERT_ND(parent_casted->get_bin_shifts() == bin_shifts);
   }
 }
 
@@ -99,11 +98,11 @@ void HashDataPage::initialize_snapshot_page(
   HashBin bin,
   uint8_t bin_bits,
   uint8_t bin_shifts) {
+  ASSERT_ND(bin_bits + bin_shifts == 64U);
   std::memset(this, 0, kPageSize);
   header_.init_snapshot(page_id, storage_id, kHashDataPageType);
   bin_ = bin;
-  bin_bits_ = bin_bits;
-  bin_shifts_ = bin_shifts;
+  protected_set_bin_shifts(bin_shifts);
 }
 
 DataPageSlotIndex HashDataPage::search_key(

--- a/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
+++ b/foedus-core/src/foedus/storage/masstree/masstree_storage_verify.cpp
@@ -226,8 +226,7 @@ ErrorStack MasstreeStoragePimpl::verify_single_thread_border(
   CHECK_AND_ASSERT(!page->is_moved());
   CHECK_AND_ASSERT(page->get_key_count() <= kBorderPageMaxSlots);
   for (SlotIndex i = 0; i < page->get_key_count(); ++i) {
-    CHECK_AND_ASSERT(!page->get_owner_id(i)->lock_.is_keylocked());
-    CHECK_AND_ASSERT(!page->get_owner_id(i)->lock_.is_rangelocked());
+    CHECK_AND_ASSERT(!page->get_owner_id(i)->lock_.is_locked());
     CHECK_AND_ASSERT(!page->get_owner_id(i)->xct_id_.is_being_written());
     CHECK_AND_ASSERT(page->get_owner_id(i)->xct_id_.get_epoch().is_valid());
     CHECK_AND_ASSERT(page->verify_slot_lengthes(i));

--- a/foedus-core/src/foedus/xct/xct_id.cpp
+++ b/foedus-core/src/foedus/xct/xct_id.cpp
@@ -194,13 +194,6 @@ std::ostream& operator<<(std::ostream& o, const McsLock& v) {
     << "</tail_block></McsLock>";
   return o;
 }
-std::ostream& operator<<(std::ostream& o, const CombinedLock& v) {
-  o << "<CombinedLock>" << *v.get_key_lock()
-    << "<other_lock>"
-      << (v.is_rangelocked() ? "R" : " ")
-    << "</other_lock></CombinedLock>";
-  return o;
-}
 
 std::ostream& operator<<(std::ostream& o, const XctId& v) {
   o << "<XctId epoch=\"" << v.get_epoch()

--- a/foedus-core/src/foedus/xct/xct_manager_pimpl.cpp
+++ b/foedus-core/src/foedus/xct/xct_manager_pimpl.cpp
@@ -581,7 +581,7 @@ bool XctManagerPimpl::precommit_xct_lock(thread::Thread* context, XctId* max_xct
   DVLOG(1) << *context << " locked write set";
 #ifndef NDEBUG
   for (uint32_t i = 0; i < write_set_size; ++i) {
-    ASSERT_ND(write_set[i].owner_id_address_->lock_.is_keylocked());
+    ASSERT_ND(write_set[i].owner_id_address_->lock_.is_locked());
   }
 #endif  // NDEBUG
   return true;

--- a/tests-core/src/foedus/storage/CMakeLists.txt
+++ b/tests-core/src/foedus/storage/CMakeLists.txt
@@ -4,4 +4,3 @@ add_subdirectory(masstree)
 add_subdirectory(sequential)
 
 add_subdirectory(hash)
-

--- a/tests-core/src/foedus/storage/sequential/test_sequential_cursor.cpp
+++ b/tests-core/src/foedus/storage/sequential/test_sequential_cursor.cpp
@@ -407,8 +407,7 @@ ErrorStack scan_task_impl(
       if (single_epoch.is_valid()) {
         EXPECT_EQ(single_epoch, record_epoch);
       }
-      EXPECT_FALSE(it.get_cur_record_owner_id()->lock_.is_keylocked());
-      EXPECT_FALSE(it.get_cur_record_owner_id()->lock_.is_rangelocked());
+      EXPECT_FALSE(it.get_cur_record_owner_id()->lock_.is_locked());
       const char* payload = it.get_cur_record_raw();
       uint64_t data = *reinterpret_cast<const uint64_t*>(payload);
       ASSERT_ND(data < observed.size());

--- a/tests-core/src/foedus/storage/sequential/test_sequential_volatile_list.cpp
+++ b/tests-core/src/foedus/storage/sequential/test_sequential_volatile_list.cpp
@@ -120,8 +120,7 @@ ErrorStack verify_result(const proc::ProcArguments& args) {
       for (uint16_t rec = 0; rec < record_count; ++rec) {
         const xct::LockableXctId* owner_id = reinterpret_cast<const xct::LockableXctId*>(
           record_pointers[rec]);
-        ASSERT_ND(!owner_id->lock_.is_keylocked());
-        ASSERT_ND(owner_id->lock_.get_version() == 0);
+        ASSERT_ND(!owner_id->lock_.is_locked());
         uint16_t payload_length = payload_lengthes[rec];
         EXPECT_GT(payload_length, 0);
         EXPECT_LE(payload_length, kMaxPayload);


### PR DESCRIPTION
This affects all storage types because now we also need to expand PageHeader.
Although individual changes were straightforward, we need an extra code review for this one.
Summary of the changes below.

McsLock/CombinedLock => Integrated into one. We will revisit range locking later.
PageVersion: 8 bytes -> 16 bytes, but 4 bytes are unused so far. we might do range-lock stuff here.
ArrayPage: Luckily we had an unused 8-byte space. Header size unchanged.
SequentialPage: Expanded both Root and Data pages for 8 bytes.
MasstreePage: Expanded both Intermediate and Border pages for 8 bytes.
HashPage (Intermediate): Expanded 48 -> 64 bytes as the data ranges must be a multiply of 16 bytes.

HashPage (Data):
This one was the trickiest. To make sure the bloom filter occupies exactly one cache line,
we wanted to keep the header size. But, all fields were used.
We thus 1) removed the bin_bits field and 2) reused common header's masstree_layer for bin_shifts.
The code gets uglier. We should rename a few fields in the common page header (eg storage_specific_1/2/...).

All testcases pass in debug/release/release-valgrind, but should have extra testing for this commit.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/hkimura/foedus_code/pull/103%23issuecomment-145391655%22%2C%20%22https%3A//github.com/hkimura/foedus_code/pull/103%23issuecomment-145598312%22%2C%20%22https%3A//github.com/hkimura/foedus_code/pull/103%23issuecomment-145598392%22%2C%20%22https%3A//github.com/hkimura/foedus_code/commit/77159f212c790a7ddbecd63858e7bb0d29dfd031%23commitcomment-13595466%22%2C%20%22https%3A//github.com/hkimura/foedus_code/commit/77159f212c790a7ddbecd63858e7bb0d29dfd031%23commitcomment-13596691%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/hkimura/foedus_code/pull/103%23issuecomment-145391655%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40wangtzh%20%2C%20this%20PR%20is%20closely%20related%20to%20our%20current%20work%20and%20affects%20many%20modules%2C%20so%20please%20review%20it.%22%2C%20%22created_at%22%3A%20%222015-10-04T21%3A53%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/702382%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hkimura%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-05T16%3A57%3A41Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9100252%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wangtzh%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-05T16%3A58%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9100252%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wangtzh%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%2077159f212c790a7ddbecd63858e7bb0d29dfd031%20foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp%2073%201051%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/hkimura/foedus_code/commit/77159f212c790a7ddbecd63858e7bb0d29dfd031%23commitcomment-13595466%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20should%20be%20dummy_%5B13%5D%3F%22%2C%20%22created_at%22%3A%20%222015-10-05T15%3A58%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9100252%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/wangtzh%22%7D%7D%2C%20%7B%22body%22%3A%20%22ah%2C%20the%20comment%20now%20tells%20a%20lie.%20The%20following%20field%20is%20an%20array%20of%20KeySlice%2C%20so%20no%20need%20to%20be%2016-byte%20aligned.%20Fixed%20the%20comment%20to%20be%20%5C%228-byte%20aligned%5C%22.%20BTW%2C%20the%20%5C%22slot%5C%22%20part%20of%20the%20data%20region%20is%20anyway%2032-byte%20aligned%20because%20it%20starts%20from%20the%20end%20and%20grows%20backward.%22%2C%20%22created_at%22%3A%20%222015-10-05T16%3A54%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/702382%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/hkimura%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp%3AL1051%20%2877159f2%29%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/wangtzh%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9100252%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/wangtzh'><img src='https://avatars.githubusercontent.com/u/9100252?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Commit 77159f212c790a7ddbecd63858e7bb0d29dfd031 foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp 73 1051'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/hkimura/foedus_code/commit/77159f212c790a7ddbecd63858e7bb0d29dfd031#commitcomment-13595466'>File: foedus-core/include/foedus/storage/masstree/masstree_page_impl.hpp:L1051 (77159f2)</a></b>
- <a href='https://github.com/wangtzh'><img border=0 src='https://avatars.githubusercontent.com/u/9100252?v=3' height=16 width=16'></a> this should be dummy_[13]?
- <a href='https://github.com/hkimura'><img border=0 src='https://avatars.githubusercontent.com/u/702382?v=3' height=16 width=16'></a> ah, the comment now tells a lie. The following field is an array of KeySlice, so no need to be 16-byte aligned. Fixed the comment to be "8-byte aligned". BTW, the "slot" part of the data region is anyway 32-byte aligned because it starts from the end and grows backward.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/hkimura/foedus_code/pull/103#issuecomment-145391655'>General Comment</a></b>
- <a href='https://github.com/hkimura'><img border=0 src='https://avatars.githubusercontent.com/u/702382?v=3' height=16 width=16'></a> @wangtzh , this PR is closely related to our current work and affects many modules, so please review it.


<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/103?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/103?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/103?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/hkimura/foedus_code/pull/103'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>