### PR TITLE
Removed the word "rdb" from top README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -82,12 +82,11 @@ Some of them are **NOT** supposed to be directly linked from client programs (_y
 
 * [foedus-core](foedus-core) : Key-value store library.
 * [foedus-util](foedus-util) : A series of utility programs to help use libfoedus.
-* foedus-rdb (not_exist_yet) : Relational database engine on top of foedus-core.
-* tests-[core/util/rdb] : Unit testcase projects.
-* experiments-[core/util/rdb] : Performance experiments projects.
+* tests-[core/util] : Unit testcase projects.
+* experiments-[core/util] : Performance experiments projects.
 * [third_party](third_party) : Third party source code used in our programs.
 
-You are supposed to link only to **foedus-core** and *foedus-rdb*.
+You are supposed to link only to **foedus-core**.
 Other projects are for internal use or to provide executables, rather than libraries.
 You can still contain all projects (or this folder's CMakeLists.txt) in your source code,
 but note that some restrictions on compiler options apply if you do so.


### PR DESCRIPTION
RDB-layer is not on top of our task list, and it will take a significant amount of work. To avoid confusion, got rid of the word for now.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/105?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/hkimura/foedus_code/pull/105'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>