### PR TITLE
ImpersonateSession now receives timeout parameter. Applied it to YCSB…

### DIFF
--- a/foedus-core/include/foedus/thread/impersonate_session.hpp
+++ b/foedus-core/include/foedus/thread/impersonate_session.hpp
@@ -107,6 +107,18 @@ struct ImpersonateSession CXX11_FINAL {
   void        wait() const;
 
   /**
+   * @brief Blocks until either the asynchronous session completes or the specified time elapses.
+   * @param[in] timeout_microsec timeout in microsec. 0 means an instant check without waiting.
+   * @return True when we observed completion.
+   * @details
+   * The behavior is undefined if is_valid()== false.
+   * It effectively calls wait_for(timeout) in order to conditionally wait for the result.
+   * This is analogous to std::future::wait_for().
+   * @pre is_valid()==true
+   */
+  bool        wait_for(uint64_t timeout_microsec) const;
+
+  /**
    * @brief Releases all resources and ownerships this session has acquired.
    * @details
    * This method is idempotent, you can call it in any state and many times.


### PR DESCRIPTION
…, not yet to other experiments.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/116?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/hkimura/foedus_code/pull/116'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>