### PR TITLE
Bug fix: the restart code assumed that all loggers had at least one l…

### DIFF
--- a/foedus-core/include/foedus/log/log_type_invoke.hpp
+++ b/foedus-core/include/foedus/log/log_type_invoke.hpp
@@ -82,7 +82,7 @@ void invoke_assert_valid(void *log_buffer);
  * Thus not inlined here.
  * This writes out an XML representation of the log entry.
  */
-void invoke_ostream(void *buffer, std::ostream *ptr);
+void invoke_ostream(const void *buffer, std::ostream *ptr);
 
 #define X(a, b, c) case a: \
   reinterpret_cast< c* >(buffer)->apply_record(context, storage_id, owner_id, payload); return;

--- a/foedus-core/src/foedus/log/log_type_invoke.cpp
+++ b/foedus-core/src/foedus/log/log_type_invoke.cpp
@@ -52,9 +52,9 @@ void invoke_apply_storage(void *buffer, Engine* engine, storage::StorageId stora
 #undef X
 
 
-#define X(a, b, c) case a: o << *reinterpret_cast< c* >(buffer); break;
-void invoke_ostream(void *buffer, std::ostream *ptr) {
-  LogHeader* header = reinterpret_cast<LogHeader*>(buffer);
+#define X(a, b, c) case a: o << *reinterpret_cast< const  c* >(buffer); break;
+void invoke_ostream(const void *buffer, std::ostream *ptr) {
+  const LogHeader* header = reinterpret_cast<const LogHeader*>(buffer);
   LogCode code = header->get_type();
   std::ostream &o = *ptr;
   switch (code) {

--- a/foedus-core/src/foedus/log/logger_ref.cpp
+++ b/foedus-core/src/foedus/log/logger_ref.cpp
@@ -113,7 +113,11 @@ LogRange LoggerRef::get_log_range(Epoch prev_epoch, Epoch until_epoch) {
       }
     }
     if (pos == count) {
-      LOG(FATAL) << "No epoch mark found for " << prev_epoch << " in logger-" << id_;
+      LOG(INFO) << "No epoch mark found for " << prev_epoch << " in logger-" << id_
+        << " This usually happens when there was no transactional log before system shutdown";
+      result.end_file_ordinal = 0;
+      result.end_offset = 0;
+      return result;
     }
   }
 

--- a/foedus-core/src/foedus/restart/restart_manager_pimpl.cpp
+++ b/foedus-core/src/foedus/restart/restart_manager_pimpl.cpp
@@ -26,6 +26,7 @@
 #include "foedus/fs/direct_io_file.hpp"
 #include "foedus/log/common_log_types.hpp"
 #include "foedus/log/log_manager.hpp"
+#include "foedus/log/log_type_invoke.hpp"
 #include "foedus/memory/aligned_memory.hpp"
 #include "foedus/savepoint/savepoint_manager.hpp"
 #include "foedus/snapshot/snapshot_manager.hpp"
@@ -100,6 +101,27 @@ ErrorStack RestartManagerPimpl::recover() {
   return kRetOk;
 }
 
+void on_non_durable_meta_log_found(
+  const log::LogHeader* entry,
+  Epoch durable_epoch,
+  uint64_t offset) {
+  std::stringstream ss;
+  ss << "    <Log offset=\"" << assorted::Hex(offset) << "\""
+    << " len=\"" << assorted::Hex(entry->log_length_) << "\""
+    << " type=\"" << assorted::Hex(entry->log_type_code_) << "\""
+    << " storage_id=\"" << assorted::Hex(entry->storage_id_) << "\"";
+  if (entry->log_length_ >= 8U) {
+    ss << " xct_id_epoch=\"" << entry->xct_id_.get_epoch_int() << "\"";
+    ss << " xct_id_ordinal=\"" << entry->xct_id_.get_ordinal() << "\"";
+  }
+  ss << ">";
+  log::invoke_ostream(entry, &ss);
+  ss << "</Log>";
+  LOG(WARNING) << "Found a meta log that is not in durable epoch (" << durable_epoch
+    << "). Probably the last run didn't invoke wait_for_commit(). The operation is discarded."
+    << " Log content:" << std::endl << ss.str();
+}
+
 ErrorStack RestartManagerPimpl::redo_meta_logs(Epoch durable_epoch, Epoch snapshot_epoch) {
   ASSERT_ND(!snapshot_epoch.is_valid() || snapshot_epoch < durable_epoch);
   LOG(INFO) << "Redoing metadata operations from " << snapshot_epoch << " to " << durable_epoch;
@@ -133,14 +155,22 @@ ErrorStack RestartManagerPimpl::redo_meta_logs(Epoch durable_epoch, Epoch snapsh
   while (cur < read_size) {
     log::BaseLogType* entry = reinterpret_cast<log::BaseLogType*>(buf + cur);
     ASSERT_ND(entry->header_.get_kind() != log::kRecordLogs);
-    cur += entry->header_.log_length_;
+    const uint32_t log_length = entry->header_.log_length_;
+    cur += log_length;
     log::LogCode type = entry->header_.get_type();
     ASSERT_ND(type != log::kLogCodeInvalid);
     if (type == log::kLogCodeFiller || type == log::kLogCodeEpochMarker) {
       continue;
     }
     Epoch epoch = entry->header_.xct_id_.get_epoch();
-    ASSERT_ND(epoch <= durable_epoch);
+    if (UNLIKELY(epoch > durable_epoch)) {
+      // NOTE: This happens. Although the meta logger itself immediately flushes all logs
+      // to durable storages, the global durable_epoch is min(all_logger_durable_epoch).
+      // Thus, when the user didn't invoke wait_on_commit, we might have to discard
+      // some meta logs that are "durable by itself" but "non-durable regarding the whole database"
+      on_non_durable_meta_log_found(&entry->header_, durable_epoch, cur - log_length);
+      continue;
+    }
     if (snapshot_epoch.is_valid() && epoch < snapshot_epoch) {
       continue;
     }

--- a/tests-core/src/foedus/restart/CMakeLists.txt
+++ b/tests-core/src/foedus/restart/CMakeLists.txt
@@ -1,3 +1,3 @@
 add_foedus_test_individual(test_restart_meta "Empty;OneArray;OneArrayOneSequential;OneMasstree;CreateDropCreate")
 
-add_foedus_test_individual(test_simple_bringup "Empty")
+add_foedus_test_individual(test_simple_bringup "Durable;NonDurable")


### PR DESCRIPTION
…og. Fixed by tolerating no-epoch marker.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/124?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/hkimura/foedus_code/pull/124'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>