### PR TITLE
Fix minimal example code in foedus-core's README

### DIFF
--- a/foedus-core/README.markdown
+++ b/foedus-core/README.markdown
@@ -236,6 +236,7 @@ Here is a minimal example program to create a key-value storage and query on it.
     const char* kProc = "myproc";
 
     foedus::ErrorStack my_proc(const foedus::proc::ProcArguments& args) {
+      foedus::thread::Thread* context = args.context_;
       foedus::Engine* engine = args.engine_;
       foedus::storage::array::ArrayStorage array(engine, kName);
       foedus::xct::XctManager* xct_manager = engine->get_xct_manager();
@@ -248,7 +249,7 @@ Here is a minimal example program to create a key-value storage and query on it.
       return foedus::kRetOk;
     }
 
-    int main(int argc, char argv) {
+    int main(int argc, char** argv) {
       foedus::EngineOptions options;
       foedus::Engine engine(options);
       engine.get_proc_manager()->pre_register(kProc, my_proc);


### PR DESCRIPTION
This PR fixes one compile error and one warning in the example code.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/130?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/hkimura/foedus_code/pull/130'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>