### PR TITLE
Recalculate last_locked_entry by scanning all entries in RLL during lock upgrade. This fixes Issue #132.

### DIFF
--- a/experiments-core/src/foedus/tpcc/tpcc_driver.cpp
+++ b/experiments-core/src/foedus/tpcc/tpcc_driver.cpp
@@ -96,8 +96,8 @@ DEFINE_int64(duration_micro, 10000000, "Duration of benchmark in microseconds.")
 // We don't vary many things in this TPCC experiment, so we just represent the configurations
 // by just one parameter.
 DEFINE_int32(hcc_policy, 1, "Specifies configurations about HCC/MOCC."
-  " default: 0 (MOCC, RLL-on, threshold 10)"
-  " 1 (OCC, RLL-off, threshold 256)"
+  " 0 (MOCC, RLL-on, threshold 10)"
+  " default: 1 (OCC, RLL-off, threshold 256)"
   " 2 (PCC, RLL-off, threshold 0)"
 );
 

--- a/foedus-core/src/foedus/xct/retrospective_lock_list.cpp
+++ b/foedus-core/src/foedus/xct/retrospective_lock_list.cpp
@@ -260,9 +260,6 @@ void RetrospectiveLockList::construct(thread::Thread* context, uint32_t read_loc
   ASSERT_ND(capacity_ >= read_set_size + write_set_size);
 
   last_active_entry_ = kLockListPositionInvalid;
-  if (read_set_size == 0 && write_set_size == 0) {
-    return;
-  }
 
   for (uint32_t i = 0; i < read_set_size; ++i) {
     RwLockableXctId* lock = read_set[i].owner_id_address_;
@@ -292,6 +289,10 @@ void RetrospectiveLockList::construct(thread::Thread* context, uint32_t read_loc
       write_set[i].owner_id_address_,
       kWriteLock,
       kNoLock);
+  }
+
+  if (last_active_entry_ == kLockListPositionInvalid) {
+    return;
   }
 
   // Now, the entries are not sorted and we might have duplicates.


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/hkimura/foedus_code/pull/133?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/hkimura/foedus_code/pull/133'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>